### PR TITLE
Add Lock Queues

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,6 +16,9 @@ Metrics/LineLength:
 Metrics/MethodLength:
   Enabled: false
 
+Metrics/ClassLength:
+  Max: 150
+
 Metrics/AbcSize:
   Enabled: false
 

--- a/app/actions/lock_action.rb
+++ b/app/actions/lock_action.rb
@@ -3,8 +3,11 @@ class LockAction < BaseAction
   def run
     transaction do
       env.merge!('params' => message_action.action_params.to_h)
-      if action.value == 'yes'
+      case action.value
+      when 'yes'
         LockCommand.call(env)
+      when 'queue'
+        QueueCommand.call(env)
       else
         Slash.reply ActionDeclinedMessage.build \
           declined_action_text: 'steal lock'

--- a/app/commands/dequeue_command.rb
+++ b/app/commands/dequeue_command.rb
@@ -1,5 +1,5 @@
-# QueueCommand handles the `/deploy queue` command.
-class QueueCommand < BaseCommand
+# DequeueCommand handles the `/deploy dequeue` command.
+class DequeueCommand < BaseCommand
   def run
     transaction do
       repo = Repository.with_name(params['repository'])
@@ -9,11 +9,11 @@ class QueueCommand < BaseCommand
       return Slash.reply(ValidationErrorMessage.build(record: env)) if env.invalid?
 
       begin
-        position = slashdeploy.queue_user_for_environment(user.user, env, message: params['message'].try(:strip))
-        if position
-          Slash.say QueuedMessage.build environment: env, position: position
+        removed = slashdeploy.dequeue_user_for_environment(user.user, env)
+        if removed
+          Slash.say DequeuedMessage.build environment: env
         else
-          Slash.say AlreadyQueuedMessage.build environment: env
+          Slash.say NotInQueueMessage.build environment: env
         end
       rescue SlashDeploy::EnvironmentUnlockedError => e
         Slash.say AlreadyUnlockedMessage.build environment: env

--- a/app/commands/dequeue_command.rb
+++ b/app/commands/dequeue_command.rb
@@ -15,7 +15,7 @@ class DequeueCommand < BaseCommand
         else
           Slash.say NotInQueueMessage.build environment: env
         end
-      rescue SlashDeploy::EnvironmentUnlockedError => e
+      rescue SlashDeploy::EnvironmentUnlockedError
         Slash.say AlreadyUnlockedMessage.build environment: env
       end
     end

--- a/app/commands/lock_command.rb
+++ b/app/commands/lock_command.rb
@@ -16,7 +16,7 @@ class LockCommand < BaseCommand
             stolen_lock: resp.stolen,
             slack_team: user.slack_team
         else
-          #user already owns the active lock
+          # user already owns the active lock
           Slash.say AlreadyLockedMessage.build \
             environment: env
         end

--- a/app/commands/lock_command.rb
+++ b/app/commands/lock_command.rb
@@ -16,6 +16,7 @@ class LockCommand < BaseCommand
             stolen_lock: resp.stolen,
             slack_team: user.slack_team
         else
+          #user already owns the active lock
           Slash.say AlreadyLockedMessage.build \
             environment: env
         end

--- a/app/commands/queue_command.rb
+++ b/app/commands/queue_command.rb
@@ -1,0 +1,24 @@
+# QueueCommand handles the `/deploy queue` command.
+class QueueCommand < BaseCommand
+  def run
+    transaction do
+      repo = Repository.with_name(params['repository'])
+      return Slash.reply(ValidationErrorMessage.build(record: repo)) if repo.invalid?
+
+      env = repo.environment(params['environment'])
+      return Slash.reply(ValidationErrorMessage.build(record: env)) if env.invalid?
+
+      begin
+        position = slashdeploy.queue_user_for_environment(user.user, env, message: params['message'].try(:strip))
+        if position
+          Slash.say QueuedMessage.build environment: env, position: position
+        else
+          Slash.say AlreadyQueuedMessage.build environment: env
+        end
+      rescue SlashDeploy::EnvironmentUnlockedError => e
+        #TODO add another message for not locked
+        Slash.say AlreadyUnlockedMessage.build environment: env
+      end
+    end
+  end
+end

--- a/app/commands/queue_command.rb
+++ b/app/commands/queue_command.rb
@@ -15,7 +15,7 @@ class QueueCommand < BaseCommand
         else
           Slash.say AlreadyQueuedMessage.build environment: env
         end
-      rescue SlashDeploy::EnvironmentUnlockedError => e
+      rescue SlashDeploy::EnvironmentUnlockedError
         Slash.say AlreadyUnlockedMessage.build environment: env
       end
     end

--- a/app/commands/slash_commands.rb
+++ b/app/commands/slash_commands.rb
@@ -17,6 +17,7 @@ class SlashCommands
     router.match match_regexp(/^boom$/), BoomCommand
     router.match match_regexp(/^#{REPO}(@#{REF})?( to #{ENV})?(?<force>!)?$/), DeployCommand
     router.match match_regexp(/^queue #{ENV} on #{REPO}(:(?<message>.*))?$/), QueueCommand
+    router.match match_regexp(/^dequeue #{ENV} on #{REPO}$/), DequeueCommand
 
     router.not_found = -> (env) do
       env['params'] = { 'not_found' => true }

--- a/app/commands/slash_commands.rb
+++ b/app/commands/slash_commands.rb
@@ -16,6 +16,7 @@ class SlashCommands
     router.match match_regexp(/^unlock #{ENV} on #{REPO}$/), UnlockCommand
     router.match match_regexp(/^boom$/), BoomCommand
     router.match match_regexp(/^#{REPO}(@#{REF})?( to #{ENV})?(?<force>!)?$/), DeployCommand
+    router.match match_regexp(/^queue #{ENV} on #{REPO}(:(?<message>.*))?$/), QueueCommand
 
     router.not_found = -> (env) do
       env['params'] = { 'not_found' => true }

--- a/app/commands/unlock_command.rb
+++ b/app/commands/unlock_command.rb
@@ -9,6 +9,15 @@ class UnlockCommand < BaseCommand
       return Slash.reply(ValidationErrorMessage.build(record: env)) if env.invalid?
 
       slashdeploy.unlock_environment(user.user, env)
+      new_active_lock = slashdeploy.give_lock_to_next_user(env)
+
+      if new_active_lock
+        slashdeploy.direct_message \
+          new_active_lock.user.slack_account_for_github_organization(repo.organization),
+          LockedMessage,
+          { environment: env, stolen_lock: false, slack_team: user.slack_team }
+      end
+
       Slash.say UnlockedMessage.build \
         environment: env
     end

--- a/app/commands/unlock_command.rb
+++ b/app/commands/unlock_command.rb
@@ -12,14 +12,21 @@ class UnlockCommand < BaseCommand
       new_active_lock = slashdeploy.give_lock_to_next_user(env)
 
       if new_active_lock
-        slashdeploy.direct_message \
+        Thread.new {
+          slashdeploy.direct_message \
           new_active_lock.user.slack_account_for_github_organization(repo.organization),
           LockedMessage,
           { environment: env, stolen_lock: false, slack_team: user.slack_team }
-      end
+        }
 
-      Slash.say UnlockedMessage.build \
-        environment: env
+        Slash.say PassedLockMessage.build \
+          environment: env,
+          new_active_lock: new_active_lock,
+          slack_team: user.slack_team
+      else
+        Slash.say UnlockedMessage.build \
+          environment: env
+      end
     end
   end
 end

--- a/app/commands/unlock_command.rb
+++ b/app/commands/unlock_command.rb
@@ -12,12 +12,14 @@ class UnlockCommand < BaseCommand
       new_active_lock = slashdeploy.give_lock_to_next_user(env)
 
       if new_active_lock
-        Thread.new {
+        Thread.new do
           slashdeploy.direct_message \
-          new_active_lock.user.slack_account_for_github_organization(repo.organization),
-          LockedMessage,
-          { environment: env, stolen_lock: false, slack_team: user.slack_team }
-        }
+            new_active_lock.user.slack_account_for_github_organization(repo.organization),
+            LockedMessage,
+            environment: env,
+            stolen_lock: false,
+            slack_team: user.slack_team
+        end
 
         Slash.say PassedLockMessage.build \
           environment: env,

--- a/app/messages/already_queued_message.rb
+++ b/app/messages/already_queued_message.rb
@@ -1,0 +1,9 @@
+class AlreadyQueuedMessage < SlackMessage
+  values do
+    attribute :environment, Environment
+  end
+
+  def to_message
+    Slack::Message.new text: text
+  end
+end

--- a/app/messages/already_unlocked_message.rb
+++ b/app/messages/already_unlocked_message.rb
@@ -1,0 +1,9 @@
+class AlreadyUnlockedMessage < SlackMessage
+  values do
+    attribute :environment, Environment
+  end
+
+  def to_message
+    Slack::Message.new text: text
+  end
+end

--- a/app/messages/dequeued_message.rb
+++ b/app/messages/dequeued_message.rb
@@ -1,0 +1,9 @@
+class DequeuedMessage < SlackMessage
+  values do
+    attribute :environment, Environment
+  end
+
+  def to_message
+    Slack::Message.new text: text
+  end
+end

--- a/app/messages/environment_locked_message.rb
+++ b/app/messages/environment_locked_message.rb
@@ -8,10 +8,10 @@ class EnvironmentLockedMessage < SlackMessage
   def to_message
     Slack::Message.new text: text(locker: locker), attachments: [
       Slack::Attachment.new(
-        title: 'Steal the lock?',
+        title: self.class.attachment_title,
         callback_id: message_action.callback_id,
         color: '#3AA3E3',
-        actions: SlackMessage.confirmation_actions
+        actions: self.class.confirmation_actions
       )
     ]
   end
@@ -20,5 +20,31 @@ class EnvironmentLockedMessage < SlackMessage
 
   def locker
     slack_user lock.user
+  end
+
+  def self.attachment_title
+    'Steal or queue up for the lock?'
+  end
+
+  # has an option to queue
+  def self.confirmation_actions
+    [
+        Slack::Attachment::Action.new(
+            name: 'yes',
+            text: 'Yes',
+            type: 'button',
+            style: 'primary',
+            value: 'yes'),
+        Slack::Attachment::Action.new(
+            name: 'queue',
+            text: 'Queue',
+            type: 'button',
+            value: 'queue'),
+        Slack::Attachment::Action.new(
+            name: 'no',
+            text: 'No',
+            type: 'button',
+            value: 'no')
+    ]
   end
 end

--- a/app/messages/environment_locked_message.rb
+++ b/app/messages/environment_locked_message.rb
@@ -29,22 +29,22 @@ class EnvironmentLockedMessage < SlackMessage
   # has an option to queue
   def self.confirmation_actions
     [
-        Slack::Attachment::Action.new(
-            name: 'yes',
-            text: 'Yes',
-            type: 'button',
-            style: 'primary',
-            value: 'yes'),
-        Slack::Attachment::Action.new(
-            name: 'queue',
-            text: 'Queue',
-            type: 'button',
-            value: 'queue'),
-        Slack::Attachment::Action.new(
-            name: 'no',
-            text: 'No',
-            type: 'button',
-            value: 'no')
+      Slack::Attachment::Action.new(
+        name: 'yes',
+        text: 'Yes',
+        type: 'button',
+        style: 'primary',
+        value: 'yes'),
+      Slack::Attachment::Action.new(
+        name: 'queue',
+        text: 'Queue',
+        type: 'button',
+        value: 'queue'),
+      Slack::Attachment::Action.new(
+        name: 'no',
+        text: 'No',
+        type: 'button',
+        value: 'no')
     ]
   end
 end

--- a/app/messages/help_message.rb
+++ b/app/messages/help_message.rb
@@ -7,6 +7,8 @@ To force a deployment, ignoring any commit statuses: /deploy REPO!
 To list known environments you can deploy a repo to: /deploy where REPO
 To lock an environment: /deploy lock ENVIRONMENT on REPO: MESSAGE
 To unlock a previously locked environment: /deploy unlock ENVIRONMENT on REPO
+To queue for an environment's lock: /deploy queue ENVIRONMENT on REPO: MESSAGE
+To remove yourself from a queue: /deploy dequeue ENVIRONMENT on REPO
 EOF
 
   values do

--- a/app/messages/not_in_queue_message.rb
+++ b/app/messages/not_in_queue_message.rb
@@ -1,0 +1,9 @@
+class NotInQueueMessage < SlackMessage
+  values do
+    attribute :environment, Environment
+  end
+
+  def to_message
+    Slack::Message.new text: text
+  end
+end

--- a/app/messages/passed_lock_message.rb
+++ b/app/messages/passed_lock_message.rb
@@ -1,0 +1,15 @@
+class PassedLockMessage < SlackMessage
+  values do
+    attribute :environment, Environment
+    attribute :new_active_lock, Lock
+  end
+
+  def to_message
+    Slack::Message.new text: text(receiver: receiver)
+  end
+
+  def receiver
+    user = slack_user(new_active_lock.user) if new_active_lock
+    user
+  end
+end

--- a/app/messages/queued_message.rb
+++ b/app/messages/queued_message.rb
@@ -1,0 +1,10 @@
+class QueuedMessage < SlackMessage
+  values do
+    attribute :environment, Environment
+    attribute :position, Fixnum
+  end
+
+  def to_message
+    Slack::Message.new text: text
+  end
+end

--- a/app/models/environment.rb
+++ b/app/models/environment.rb
@@ -35,6 +35,7 @@ class Environment < ActiveRecord::Base
     locks.active.create!(user: user, message: message)
   end
 
+  # Queues a user for the lock
   def queue!(user, message = nil)
     locks.waiting.create!(user: user, message: message)
     locks.waiting.length
@@ -48,6 +49,11 @@ class Environment < ActiveRecord::Base
   # Returns true if this environment is locked.
   def locked?
     active_lock.present?
+  end
+
+  # Returns the first lock in the queue, or nil
+  def next_in_line
+    locks.waiting.first
   end
 
   # Returns true if the environment already queued the user for a lock

--- a/app/models/environment.rb
+++ b/app/models/environment.rb
@@ -43,9 +43,7 @@ class Environment < ActiveRecord::Base
 
   # Removes a user from the queue
   def dequeue!(user)
-    locks.waiting.for_user(user).each do |lock|
-      lock.dequeue!
-    end
+    locks.waiting.for_user(user).each(&:dequeue!)
   end
 
   # Returns the currently active lock for this environment, or nil if there is none.
@@ -64,7 +62,7 @@ class Environment < ActiveRecord::Base
   end
 
   # Returns true if the environment already queued the user for a lock
-  def has_waiting_user?(user)
+  def waiting_user?(user)
     locks.waiting.for_user(user).present?
   end
 

--- a/app/models/environment.rb
+++ b/app/models/environment.rb
@@ -41,6 +41,13 @@ class Environment < ActiveRecord::Base
     locks.waiting.length
   end
 
+  # Removes a user from the queue
+  def dequeue!(user)
+    locks.waiting.for_user(user).each do |lock|
+      lock.dequeue!
+    end
+  end
+
   # Returns the currently active lock for this environment, or nil if there is none.
   def active_lock
     locks.active.first

--- a/app/models/environment.rb
+++ b/app/models/environment.rb
@@ -35,6 +35,11 @@ class Environment < ActiveRecord::Base
     locks.active.create!(user: user, message: message)
   end
 
+  def queue!(user, message = nil)
+    locks.waiting.create!(user: user, message: message)
+    locks.waiting.length
+  end
+
   # Returns the currently active lock for this environment, or nil if there is none.
   def active_lock
     locks.active.first
@@ -43,6 +48,11 @@ class Environment < ActiveRecord::Base
   # Returns true if this environment is locked.
   def locked?
     active_lock.present?
+  end
+
+  # Returns true if the environment already queued the user for a lock
+  def has_waiting_user?(user)
+    locks.waiting.for_user(user).present?
   end
 
   # Override the aliases setter to filter out aliases that match the name of

--- a/app/models/lock.rb
+++ b/app/models/lock.rb
@@ -7,6 +7,10 @@ class Lock < ActiveRecord::Base
   scope :waiting, -> { where(waiting: true) }
   scope :for_user, -> (user) { where(user_id: user.id) }
 
+  def lock!
+    update_attributes!(active: true)
+  end
+
   def unlock!
     update_attributes!(active: false)
   end

--- a/app/models/lock.rb
+++ b/app/models/lock.rb
@@ -4,9 +4,15 @@ class Lock < ActiveRecord::Base
   belongs_to :user
 
   scope :active, -> { where(active: true) }
+  scope :waiting, -> { where(waiting: true) }
+  scope :for_user, -> (user) { where(user_id: user.id) }
 
   def unlock!
     update_attributes!(active: false)
+  end
+
+  def dequeue!
+    update_attributes!(waiting: false)
   end
 
   def repository

--- a/app/views/messages/already_queued.text.erb
+++ b/app/views/messages/already_queued.text.erb
@@ -1,1 +1,1 @@
-You have already queued for *<%= @environment %>*
+You have already queued for or locked *<%= @environment %>*

--- a/app/views/messages/already_queued.text.erb
+++ b/app/views/messages/already_queued.text.erb
@@ -1,0 +1,1 @@
+You have already queued for *<%= @environment %>*

--- a/app/views/messages/already_unlocked.text.erb
+++ b/app/views/messages/already_unlocked.text.erb
@@ -1,0 +1,1 @@
+*<%= @environment %>* is already unlocked. No need to queue.

--- a/app/views/messages/dequeued.text.erb
+++ b/app/views/messages/dequeued.text.erb
@@ -1,0 +1,1 @@
+You have been removed from the queue for *<%= @environment %>*

--- a/app/views/messages/not_in_queue.text.erb
+++ b/app/views/messages/not_in_queue.text.erb
@@ -1,0 +1,1 @@
+You were not queued for *<%= @environment %>*

--- a/app/views/messages/passed_lock.text.erb
+++ b/app/views/messages/passed_lock.text.erb
@@ -1,0 +1,1 @@
+Lock for *<%= @environment %>* on <%= @environment.repository %><% if @new_active_lock %> passed to <@<%= @receiver.slack_username %>> <% end %>

--- a/app/views/messages/queued.text.erb
+++ b/app/views/messages/queued.text.erb
@@ -1,0 +1,1 @@
+Queued for *<%= @environment %>* on <%= @environment.repository %>. You are #<%= @position %> in line

--- a/db/migrate/20161005204501_add_waiting_to_locks.rb
+++ b/db/migrate/20161005204501_add_waiting_to_locks.rb
@@ -1,0 +1,5 @@
+class AddWaitingToLocks < ActiveRecord::Migration
+  def change
+    add_column :locks, :waiting, :boolean, default: false, null: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -135,7 +135,8 @@ CREATE TABLE locks (
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     environment_id integer NOT NULL,
-    user_id integer NOT NULL
+    user_id integer NOT NULL,
+    waiting boolean DEFAULT false NOT NULL
 );
 
 
@@ -652,4 +653,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160727164721');
 INSERT INTO schema_migrations (version) VALUES ('20160804213314');
 
 INSERT INTO schema_migrations (version) VALUES ('20160815212720');
+
+INSERT INTO schema_migrations (version) VALUES ('20161005204501');
 

--- a/lib/slashdeploy/errors.rb
+++ b/lib/slashdeploy/errors.rb
@@ -21,6 +21,10 @@ module SlashDeploy
     end
   end
 
+  # Raised for queuing, which cannot be performed on an unlocked environment.
+  class EnvironmentUnlockedError < Error
+  end
+
   # Can be raised when there is no user to perform an auto deployment.
   class NoAutoDeployUser < Error
   end

--- a/lib/slashdeploy/service.rb
+++ b/lib/slashdeploy/service.rb
@@ -109,7 +109,7 @@ module SlashDeploy
 
       fail EnvironmentUnlockedError, 'no active lock' unless environment.locked?
 
-      return if environment.has_waiting_user?(user) or environment.active_lock.user == user
+      return if environment.waiting_user?(user) || environment.active_lock.user == user
       position = environment.queue! user, options[:message]
       position
     end
@@ -126,7 +126,7 @@ module SlashDeploy
 
       fail EnvironmentUnlockedError, 'no active lock' unless environment.locked?
 
-      return false unless environment.has_waiting_user?(user)
+      return false unless environment.waiting_user?(user)
       environment.dequeue! user
       true
     end

--- a/lib/slashdeploy/service.rb
+++ b/lib/slashdeploy/service.rb
@@ -95,6 +95,24 @@ module SlashDeploy
         stolen: stolen
     end
 
+    # Attempts to queue the user for the environment lock.
+    # Throws an error if there is no active lock for the environment.
+    #
+    # environment - An Environment to lock.
+    # options     - A hash of options.
+    #               :message - An optional message.
+    #
+    # Returns a waiting Lock or Nil, if the user is already queued.
+    def queue_user_for_environment(user, environment, options = {})
+      authorize! user, environment.repository
+
+      fail EnvironmentUnlockedError, 'no active lock' unless environment.locked?
+
+      return if environment.has_waiting_user(user)
+      position = environment.queue! user, options[:message]
+      position
+    end
+
     # Unlocks an environment.
     #
     # environment - An Environment to unlock

--- a/spec/features/commands_spec.rb
+++ b/spec/features/commands_spec.rb
@@ -360,10 +360,10 @@ RSpec.feature 'Slash Commands' do
 
   def steal_lock_attachment(callback_id)
     Slack::Attachment.new(
-      title: 'Steal the lock?',
+      title: EnvironmentLockedMessage.attachment_title,
       callback_id: callback_id,
       color: '#3AA3E3',
-      actions: SlackMessage.confirmation_actions
+      actions: EnvironmentLockedMessage.confirmation_actions
     )
   end
 end


### PR DESCRIPTION
This PR adds queues for environments.

There are two ways to add yourself to a queue:
1. Through a "Queue" button when you try to lock an already locked environment

<img width="471" alt="screen shot 2016-10-06 at 5 03 19 pm" src="https://cloud.githubusercontent.com/assets/4641516/19174883/f81a7bee-8be6-11e6-8edd-82f48cc5e352.png">
1. Through `/deploy queue ENVIRONMENT on REPO: MESSAGE`

When the active lock for an environment is `/unlock`'ed, the lock will pass to the next user, and the user receives a personal notification from slashdeploy.

There is also a `/deploy dequeue ENVIRONMENT on REPO` command, for removing yourself from a queue.

Adding tests, just wanted to set this up for a clean diff. 
