### PR TITLE
Message github without context if Autodeploy is ready!

### DIFF
--- a/lib/slashdeploy/service.rb
+++ b/lib/slashdeploy/service.rb
@@ -179,10 +179,16 @@ module SlashDeploy
             lock: environment.active_lock
           return
         end
+
+        # An auto_deployment in the 'ready' state doesn't need context checks.
+        # So when creating the GitHub Deployment we set force to true.
         github.create_deployment(
           auto_deployment.deployer,
-          deployment_request(environment, auto_deployment.sha)
+          deployment_request(
+            environment, auto_deployment.sha, force: true
+          )
         )
+
       ensure
         auto_deployment.done!
       end

--- a/spec/features/auto_deploy_spec.rb
+++ b/spec/features/auto_deploy_spec.rb
@@ -30,7 +30,8 @@ RSpec.feature 'Auto Deployment' do
       DeploymentRequest.new(
         repository: 'baxterthehacker/public-repo',
         ref: '0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c',
-        environment: 'production'
+        environment: 'production',
+        force: true
       )
 
     push_event 'secret', sender: { id: github_accounts(:david).id }
@@ -48,14 +49,16 @@ RSpec.feature 'Auto Deployment' do
       DeploymentRequest.new(
         repository: 'baxterthehacker/public-repo',
         ref: '0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c',
-        environment: 'production'
+        environment: 'production',
+        force: true
       )
     expect(github).to receive(:create_deployment).with \
       users(:david),
       DeploymentRequest.new(
         repository: 'baxterthehacker/public-repo',
         ref: '0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c',
-        environment: 'staging'
+        environment: 'staging',
+        force: true
       )
 
     push_event 'secret', sender: { id: github_accounts(:david).id }
@@ -83,7 +86,8 @@ RSpec.feature 'Auto Deployment' do
       DeploymentRequest.new(
         repository: 'baxterthehacker/public-repo',
         ref: '0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c',
-        environment: 'production'
+        environment: 'production',
+        force: true
       )
 
     push_event 'secret', sender: { id: 1234567 }
@@ -119,7 +123,8 @@ RSpec.feature 'Auto Deployment' do
       DeploymentRequest.new(
         repository: 'baxterthehacker/public-repo',
         ref: '0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c',
-        environment: 'production'
+        environment: 'production',
+        force: true
       )
 
     status_event 'secret', context: 'security/brakeman', state: 'success'
@@ -150,14 +155,16 @@ RSpec.feature 'Auto Deployment' do
       DeploymentRequest.new(
         repository: 'baxterthehacker/public-repo',
         ref: '0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c',
-        environment: 'production'
+        environment: 'production',
+        force: true
       )
     expect(github).to receive(:create_deployment).with \
       users(:david),
       DeploymentRequest.new(
         repository: 'baxterthehacker/public-repo',
         ref: '0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c',
-        environment: 'staging'
+        environment: 'staging',
+        force: true
       )
 
     status_event 'secret', context: 'security/brakeman', state: 'success'
@@ -191,7 +198,8 @@ RSpec.feature 'Auto Deployment' do
       DeploymentRequest.new(
         repository: 'baxterthehacker/public-repo',
         ref: '0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c',
-        environment: 'production'
+        environment: 'production',
+        force: true
       )
     status_event 'secret', context: 'ci/circleci', state: 'success'
   end
@@ -229,7 +237,8 @@ RSpec.feature 'Auto Deployment' do
       DeploymentRequest.new(
         repository: 'baxterthehacker/public-repo',
         ref: '0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c',
-        environment: 'production'
+        environment: 'production',
+        force: true
       )
     status_event 'secret', context: 'security/brakeman', state: 'success'
   end
@@ -290,7 +299,8 @@ RSpec.feature 'Auto Deployment' do
       DeploymentRequest.new(
         repository: 'baxterthehacker/public-repo',
         ref: commits[:b],
-        environment: 'production'
+        environment: 'production',
+        force: true
       )
     )
     status_event 'secret', sha: commits[:b], context: 'security/brakeman', state: 'success'
@@ -301,7 +311,8 @@ RSpec.feature 'Auto Deployment' do
       DeploymentRequest.new(
         repository: 'baxterthehacker/public-repo',
         ref: commits[:c],
-        environment: 'production'
+        environment: 'production',
+        force: true
       )
     )
     status_event 'secret', sha: commits[:c], context: 'ci/circleci', state: 'success'


### PR DESCRIPTION
**Issue:**

Sometimes an AutoDeployment never occurs and a user waits forever.

**Root cause:**

Sometimes (like once a day) if we send the list of context checks when requesting a Github Deployment, github will reject our attempt because of an apparent race condition related to "required context checks".

**Resolution**

If an an AutoDeployment transitions to the 'ready' state, we don't need to pass a list of required context checks when creating the GitHub Deployment.

**Hints**

An AutoDeployment basically just tracks the state of a commit,
then does a `/deploy` once it transitions to the "ready" state.

Basically, that logic is encapsulated here:

 https://github.com/remind101/slashdeploy/blob/master/lib/slashdeploy/service.rb#L60

So, it's at this point that we'd want to ignore context checks:

 https://github.com/remind101/slashdeploy/blob/master/lib/slashdeploy/service.rb#L182-L185

**Changed:**

        modified:   lib/slashdeploy/service.rb
        modified:   spec/features/auto_deploy_spec.rb

**Related:**

https://app.asana.com/0/344289131135984/512056087737341