### PR TITLE
Support configuring environments via .slashdeploy.yml

### DIFF
--- a/app/commands/check_command.rb
+++ b/app/commands/check_command.rb
@@ -6,6 +6,7 @@ class CheckCommand < BaseCommand
       return Slash.reply(ValidationErrorMessage.build(record: repo)) if repo.invalid?
 
       env = repo.environment(params['environment'])
+      return Slash.reply(EnvironmentsMessage.build(repository: repo)) unless env
       return Slash.reply(ValidationErrorMessage.build(record: env)) if env.invalid?
 
       Slash.say CheckMessage.build \

--- a/app/commands/deploy_command.rb
+++ b/app/commands/deploy_command.rb
@@ -6,6 +6,7 @@ class DeployCommand < BaseCommand
       return Slash.reply(ValidationErrorMessage.build(record: repo)) if repo.invalid?
 
       env = repo.environment(params['environment'])
+      return Slash.reply(EnvironmentsMessage.build(repository: repo)) unless env
       return Slash.reply(ValidationErrorMessage.build(record: env)) if env.invalid?
 
       begin

--- a/app/commands/lock_command.rb
+++ b/app/commands/lock_command.rb
@@ -6,6 +6,7 @@ class LockCommand < BaseCommand
       return Slash.reply(ValidationErrorMessage.build(record: repo)) if repo.invalid?
 
       env = repo.environment(params['environment'])
+      return Slash.reply(EnvironmentsMessage.build(repository: repo)) unless env
       return Slash.reply(ValidationErrorMessage.build(record: env)) if env.invalid?
 
       begin

--- a/app/commands/unlock_command.rb
+++ b/app/commands/unlock_command.rb
@@ -6,6 +6,7 @@ class UnlockCommand < BaseCommand
       return Slash.reply(ValidationErrorMessage.build(record: repo)) if repo.invalid?
 
       env = repo.environment(params['environment'])
+      return Slash.reply(EnvironmentsMessage.build(repository: repo)) unless env
       return Slash.reply(ValidationErrorMessage.build(record: env)) if env.invalid?
 
       slashdeploy.unlock_environment(user, env)

--- a/app/github/push_event.rb
+++ b/app/github/push_event.rb
@@ -6,7 +6,10 @@ class PushEvent < GitHubEventHandler
 
     logger.info "ref=#{event['ref']} sha=#{sha} sender=#{event['sender']['login']}"
     transaction do
-      slashdeploy.update_repository_config(repository) if default_branch?
+      if default_branch?
+        logger.info "syncing #{SlashDeploy::CONFIG_FILE_NAME}"
+        slashdeploy.update_repository_config(repository)
+      end
       return logger.info 'not configured for automatic deployments' unless environments
       environments.each do |environment|
         auto_deployment = slashdeploy.create_auto_deployment(environment, sha, deployer)
@@ -17,6 +20,8 @@ class PushEvent < GitHubEventHandler
 
   private
 
+  # Returns true if the ref that was pushed to is the default branch for the
+  # repository.
   def default_branch?
     event['ref'] == "refs/heads/#{event['repository']['default_branch']}"
   end

--- a/app/github/push_event.rb
+++ b/app/github/push_event.rb
@@ -6,6 +6,7 @@ class PushEvent < GitHubEventHandler
 
     logger.info "ref=#{event['ref']} sha=#{sha} sender=#{event['sender']['login']}"
     transaction do
+      slashdeploy.update_repository_config(repository) if default_branch?
       return logger.info 'not configured for automatic deployments' unless environments
       environments.each do |environment|
         auto_deployment = slashdeploy.create_auto_deployment(environment, sha, deployer)
@@ -15,6 +16,10 @@ class PushEvent < GitHubEventHandler
   end
 
   private
+
+  def default_branch?
+    event['ref'] == "refs/heads/#{event['repository']['default_branch']}"
+  end
 
   # Returns true if this push event was triggered from a fork.
   def fork?

--- a/app/models/environment.rb
+++ b/app/models/environment.rb
@@ -49,20 +49,52 @@ class Environment < ActiveRecord::Base
     active_lock.present?
   end
 
+  # Returns true if the provided name, matches the canonical environment name,
+  # or one of it's aliases.
+  def match_name?(name)
+    return true if self.name == name
+    return true if config.aliases.include?(name)
+    false
+  end
+
+  # Returns the aliases for this environment.
+  def aliases
+    config? ? config.aliases : super
+  end
+
   # Override the aliases setter to filter out aliases that match the name of
   # the environment.
   def aliases=(aliases)
+    check_config!
     super((aliases || []).select { |a| a != name })
+  end
+
+  # Override the required_contexts setter to ensure it's not used when the repo
+  # is a config file set.
+  def required_contexts=(*args)
+    check_config!
+    super(*args)
   end
 
   # Configures this environment to auto deploy the given branch.
   def configure_auto_deploy(ref)
+    check_config!
     self.update_attributes!(auto_deploy_ref: ref)
   end
 
   # Checks if this environment is configured to automatically deploy the given ref.
   def auto_deploy?(ref)
     auto_deploy_ref == ref
+  end
+
+  # Returns the ref that should trigger CD to this environment.
+  def auto_deploy_ref
+    continuous_delivery_config? ? config.continuous_delivery.ref : super
+  end
+
+  # Returns the required commit status contexts for CD to this environment.
+  def required_contexts
+    continuous_delivery_config? ? config.continuous_delivery.required_contexts : super
   end
 
   # Returns true if this environment is configured to automatically deploy.
@@ -94,6 +126,23 @@ class Environment < ActiveRecord::Base
 
   def installation
     repository.installation
+  end
+
+  def check_config!
+    fail("This repository is configured from .slashdeploy.yaml") if repository && repository.config?
+  end
+
+  def config?
+    config.present?
+  end
+
+  def continuous_delivery_config?
+    config? && config.continuous_delivery.present?
+  end
+
+  def config
+    return unless repository && repository.config?
+    repository.config.environments[name]
   end
 
   def to_s

--- a/app/views/documentation/index.html.erb
+++ b/app/views/documentation/index.html.erb
@@ -3,7 +3,7 @@
     <ul class="nav nav-pills nav-stacked">
       <li role="presentation"><a href="#installation">Installation</a></li>
       <li role="presentation"><a href="#slash-command">Slash Command</a></li>
-      <li role="presentation"><a href="#auto-deployment">Auto Deployment</a></li>
+      <li role="presentation"><a href="#continuous-delivery">Continuous Delivery</a></li>
       <li role="presentation"><a href="#faq">FAQ</a></li>
     </ul>
   </div>
@@ -42,8 +42,29 @@
     <p>When I'm done testing my changes, I can unlock the environment so others can deploy to it again.</p>
     <p><code>/deploy unlock staging on acme-inc/api</code></p>
     <hr />
-    <h5 id="auto-deployment">Auto Deployment</h5>
+    <h5 id="continuous-delivery">Continuous Delivery</h5>
     <p>You can configure SlashDeploy to automatically deploy a branch to an environment when you push code to GitHub or when a set of commit status contexts succeeds.</p>
+    <p>To configure CD, you add a <code>.slashdeploy.yml</code> file to the root of the repository. Here's an example config file that will automatically deploy the <code>master</code> branch to the <code>production</code> environment, once tests are passing on CircleCI:</p>
+    <p>
+      <pre>---
+production:
+  
+  # Allows us to reference this using "production" or a short alias, "prod".
+  aliases:
+    - prod
+
+  # Enable continuous delivery for this environment.
+  continuous_delivery:
+    # You can specify any git "ref" (tag, branch, etc) to auto deploy when
+    # pushed to.
+    ref: refs/heads/master
+
+    # If you want to only deploy when a set of GitHub commit statuses are
+    # passing, you can configure those here. If none are provided, SlashDeploy
+    # will deploy when new commits are pushed to the git ref.
+    required_contexts:
+      - ci/circleci</pre>
+    </p>
     <hr />
     <h5 id="faq">FAQ</h5>
     <dl>

--- a/app/views/messages/environments.text.erb
+++ b/app/views/messages/environments.text.erb
@@ -1,8 +1,8 @@
-<% if @repository.environments.empty? %>
-I don't know about any environments for <%= @repository %>
+<% if @repository.known_environments.empty? %>
+I don't know about any environments for <%= @repository %>. For details about configuring environments, see <https://slashdeploy.io/docs>.
 <% else %>
 I know about these environments for <%= @repository %>:
-  <% @repository.environments.each do |environment| %>
+  <% @repository.known_environments.each do |environment| %>
 * <%= environment.name %>
   <% end %>
 <% end %>

--- a/db/migrate/20180308001951_add_raw_config_to_repository.rb
+++ b/db/migrate/20180308001951_add_raw_config_to_repository.rb
@@ -1,0 +1,5 @@
+class AddRawConfigToRepository < ActiveRecord::Migration
+  def change
+    add_column :repositories, :raw_config, :text
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.6.6
--- Dumped by pg_dump version 9.6.6
+-- Dumped from database version 9.6.1
+-- Dumped by pg_dump version 9.6.1
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -198,7 +198,8 @@ CREATE TABLE repositories (
     updated_at timestamp without time zone NOT NULL,
     default_environment character varying,
     github_secret character varying NOT NULL,
-    installation_id integer
+    installation_id integer,
+    raw_config text
 );
 
 
@@ -690,4 +691,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160815212720');
 INSERT INTO schema_migrations (version) VALUES ('20161217031700');
 
 INSERT INTO schema_migrations (version) VALUES ('20170704235901');
+
+INSERT INTO schema_migrations (version) VALUES ('20180308001951');
 

--- a/lib/github.rb
+++ b/lib/github.rb
@@ -25,5 +25,9 @@ module GitHub
     def access?(_user, _repository)
       fail NotImplementedError
     end
+
+    def contents(_repository, _path)
+      fail NotImplementedError
+    end
   end
 end

--- a/lib/github/client/fake.rb
+++ b/lib/github/client/fake.rb
@@ -41,6 +41,10 @@ module GitHub
         deployments[repository][environment].last
       end
 
+      def contents(_repository, _path)
+        nil
+      end
+
       def reset
         @ids = 1
         @commits = Hash.new do |commits, repo|

--- a/lib/github/client/octokit.rb
+++ b/lib/github/client/octokit.rb
@@ -1,3 +1,4 @@
+require 'base64'
 require 'octokit'
 
 module GitHub
@@ -35,6 +36,14 @@ module GitHub
         true
       rescue ::Octokit::NotFound
         false
+      end
+
+      def contents(repository, path)
+        client = repository.installation.octokit_client
+        contents = client.contents(repository.name, path: path)
+        Base64.decode64(contents.content)
+      rescue ::Octokit::NotFound
+        nil
       end
 
       private

--- a/lib/slashdeploy.rb
+++ b/lib/slashdeploy.rb
@@ -13,6 +13,12 @@ module SlashDeploy
   # http://rubular.com/r/Ecpz7KLRyE
   GITHUB_REPO_REGEX = %r{([\w\-]+)\/([\w\-\.]+)}
 
+  # The file name for SlashDeploy configuration. Similiar to something like
+  # .circleci or .travis.yml. Note that this much match that SlashDeploy
+  # integrations permissions configuration, so that it only has read access to
+  # this single file.
+  CONFIG_FILE_NAME = ".slashdeploy.yml"
+
   autoload :Service, 'slashdeploy/service'
   autoload :Auth,    'slashdeploy/auth'
 

--- a/lib/slashdeploy.rb
+++ b/lib/slashdeploy.rb
@@ -13,14 +13,16 @@ module SlashDeploy
   # http://rubular.com/r/Ecpz7KLRyE
   GITHUB_REPO_REGEX = %r{([\w\-]+)\/([\w\-\.]+)}
 
-  # The file name for SlashDeploy configuration. Similiar to something like
-  # .circleci or .travis.yml. Note that this much match that SlashDeploy
-  # integrations permissions configuration, so that it only has read access to
-  # this single file.
+  # SlashDeploy should _only_ need read access to this file path. Ensure this
+  # value matches SlashDeploy's Github integration permission configuration
+  # labeled "Single File".
+  #
+  # See https://github.com/organizations/<org>/settings/apps/slashdeploy/permissions
   CONFIG_FILE_NAME = ".slashdeploy.yml"
 
   autoload :Service, 'slashdeploy/service'
   autoload :Auth,    'slashdeploy/auth'
+  autoload :Config,  'slashdeploy/config'
 
   def self.github_app
     @github_app ||= GitHub::App.build(Rails.configuration.x.github_app_id, Rails.configuration.x.github_app_private_pem)

--- a/lib/slashdeploy/config.rb
+++ b/lib/slashdeploy/config.rb
@@ -1,0 +1,46 @@
+module SlashDeploy
+  # Config is a Ruby representation of the .slashdeploy.yml configuration file.
+  #
+  # Example
+  #
+  #   ---
+  #   environments:
+  #     production:
+  #       aliases:
+  #         - prod
+  #       continuous_delivery:
+  #         ref: refs/heads/master
+  #         required_contexts:
+  #           - ci/circleci
+  #     staging:
+  #       aliases:
+  #         - stage
+  class Config
+    include Virtus.model
+
+    class ContinuousDelivery
+      include Virtus.model
+
+      attribute :ref, String
+      attribute :required_contexts, Array[String]
+    end
+
+    class Environment
+      include Virtus.model
+
+      attribute :aliases, Array[String]
+      attribute :continuous_delivery, ContinuousDelivery
+    end
+
+    attribute :environments, Hash[String => Environment]
+
+    # Public: Loads the raw yaml and initializes a new Config object from it.
+    #
+    # yaml - raw YAML formatted string
+    #
+    # Returns Config.
+    def self.from_yaml(yaml)
+      new Psych.safe_load(yaml)
+    end
+  end
+end

--- a/lib/slashdeploy/service.rb
+++ b/lib/slashdeploy/service.rb
@@ -20,6 +20,12 @@ module SlashDeploy
       slack.direct_message(account, message)
     end
 
+    # Pulls the latest .slashdeploy.yml file from the default branch.
+    def update_repository_config(repository)
+      raw_config = github.contents(repository, SlashDeploy::CONFIG_FILE_NAME)
+      repository.update_column(:raw_config, raw_config)
+    end
+
     # Creates a new AutoDeployment for the given sha.
     #
     # environment - Environment to deploy to.

--- a/lib/slashdeploy/service.rb
+++ b/lib/slashdeploy/service.rb
@@ -23,7 +23,7 @@ module SlashDeploy
     # Pulls the latest .slashdeploy.yml file from the default branch.
     def update_repository_config(repository)
       raw_config = github.contents(repository, SlashDeploy::CONFIG_FILE_NAME)
-      repository.update_column(:raw_config, raw_config)
+      repository.configure!(raw_config)
     end
 
     # Creates a new AutoDeployment for the given sha.

--- a/spec/features/auto_deploy_spec.rb
+++ b/spec/features/auto_deploy_spec.rb
@@ -8,6 +8,7 @@ RSpec.feature 'Auto Deployment' do
   before do
     allow(SlashDeploy.service).to receive(:github).and_return(github)
     allow(SlashDeploy.service).to receive(:slack).and_return(slack)
+    allow(github).to receive(:contents).and_return(nil)
   end
 
   scenario 'receiving a `push` event from GitHub when the repo is not enabled for auto deployments' do

--- a/spec/features/auto_deploy_spec.rb
+++ b/spec/features/auto_deploy_spec.rb
@@ -22,9 +22,14 @@ RSpec.feature 'Auto Deployment' do
   end
 
   scenario 'receiving a `push` event from GitHub when the production environment is configured to auto deploy the master branch' do
-    repo = Repository.with_name('baxterthehacker/public-repo')
-    environment = repo.environment('production')
-    environment.configure_auto_deploy('refs/heads/master')
+    config = <<-YAML.strip_heredoc
+    environments:
+      production:
+        continuous_delivery:
+          ref: refs/heads/master
+    YAML
+
+    allow(github).to receive(:contents).and_return(config)
 
     expect(github).to receive(:create_deployment).with \
       users(:david),
@@ -39,11 +44,17 @@ RSpec.feature 'Auto Deployment' do
   end
 
   scenario 'receiving a `push` event from GitHub when the staging and production environments are configured to auto deploy the master branch' do
-    repo = Repository.with_name('baxterthehacker/public-repo')
-    production = repo.environment('production')
-    production.configure_auto_deploy('refs/heads/master')
-    staging = repo.environment('staging')
-    staging.configure_auto_deploy('refs/heads/master')
+    config = <<-YAML.strip_heredoc
+    environments:
+      production:
+        continuous_delivery:
+          ref: refs/heads/master
+      staging:
+        continuous_delivery:
+          ref: refs/heads/master
+    YAML
+
+    allow(github).to receive(:contents).and_return(config)
 
     expect(github).to receive(:create_deployment).with \
       users(:david),
@@ -66,9 +77,18 @@ RSpec.feature 'Auto Deployment' do
   end
 
   scenario 'receiving a `push` event when the environment is locked' do
+    config = <<-YAML.strip_heredoc
+    environments:
+      production:
+        continuous_delivery:
+          ref: refs/heads/master
+    YAML
+
+    allow(github).to receive(:contents).and_return(config)
+
     repo = Repository.with_name('baxterthehacker/public-repo')
+    repo.configure!(config)
     environment = repo.environment('production')
-    environment.configure_auto_deploy('refs/heads/master')
     environment.lock! users(:david)
 
     expect(slack).to receive(:direct_message).with \
@@ -78,9 +98,14 @@ RSpec.feature 'Auto Deployment' do
   end
 
   scenario 'receiving a `push` event from GitHub from a user that has never logged into slashdeploy' do
-    repo = Repository.with_name('baxterthehacker/public-repo')
-    environment = repo.environment('production')
-    environment.configure_auto_deploy('refs/heads/master')
+    config = <<-YAML.strip_heredoc
+    environments:
+      production:
+        continuous_delivery:
+          ref: refs/heads/master
+    YAML
+
+    allow(github).to receive(:contents).and_return(config)
 
     expect(github).to receive(:create_deployment).with \
       installations(:baxterthehacker),
@@ -95,9 +120,18 @@ RSpec.feature 'Auto Deployment' do
   end
 
   scenario 'receiving a `push` event from GitHub from a user that has never logged into slashdeploy, when the environment is locked' do
+    config = <<-YAML.strip_heredoc
+    environments:
+      production:
+        continuous_delivery:
+          ref: refs/heads/master
+    YAML
+
+    allow(github).to receive(:contents).and_return(config)
+
     repo = Repository.with_name('baxterthehacker/public-repo')
+    repo.configure!(config)
     environment = repo.environment('production')
-    environment.configure_auto_deploy('refs/heads/master')
     environment.lock! users(:david)
 
     expect(github).to_not receive(:create_deployment)
@@ -106,10 +140,17 @@ RSpec.feature 'Auto Deployment' do
   end
 
   scenario 'receiving a `status` event when the repository is configured to deploy on successful commit statuses' do
-    repo = Repository.with_name('baxterthehacker/public-repo')
-    environment = repo.environment('production')
-    environment.required_contexts = ['ci/circleci', 'security/brakeman']
-    environment.configure_auto_deploy('refs/heads/master')
+    config = <<-YAML.strip_heredoc
+    environments:
+      production:
+        continuous_delivery:
+          ref: refs/heads/master
+          required_contexts:
+          - ci/circleci
+          - security/brakeman
+    YAML
+
+    allow(github).to receive(:contents).and_return(config)
 
     expect(slack).to receive(:direct_message).with \
       slack_accounts(:david_baxterthehacker),
@@ -132,13 +173,23 @@ RSpec.feature 'Auto Deployment' do
   end
 
   scenario 'receiving a `status` event when multiple environments are configured to deploy on successful commit statuses' do
-    repo = Repository.with_name('baxterthehacker/public-repo')
-    production = repo.environment('production')
-    production.required_contexts = ['ci/circleci', 'security/brakeman']
-    production.configure_auto_deploy('refs/heads/master')
-    staging = repo.environment('staging')
-    staging.required_contexts = ['ci/circleci', 'security/brakeman']
-    staging.configure_auto_deploy('refs/heads/master')
+    config = <<-YAML.strip_heredoc
+    environments:
+      production:
+        continuous_delivery:
+          ref: refs/heads/master
+          required_contexts:
+          - ci/circleci
+          - security/brakeman
+      staging:
+        continuous_delivery:
+          ref: refs/heads/master
+          required_contexts:
+          - ci/circleci
+          - security/brakeman
+    YAML
+
+    allow(github).to receive(:contents).and_return(config)
 
     expect(slack).to receive(:direct_message).with \
       slack_accounts(:david_baxterthehacker),
@@ -172,10 +223,17 @@ RSpec.feature 'Auto Deployment' do
   end
 
   scenario 'receiving a `failed` status event' do
-    repo = Repository.with_name('baxterthehacker/public-repo')
-    environment = repo.environment('production')
-    environment.required_contexts = ['ci/circleci', 'security/brakeman']
-    environment.configure_auto_deploy('refs/heads/master')
+    config = <<-YAML.strip_heredoc
+    environments:
+      production:
+        continuous_delivery:
+          ref: refs/heads/master
+          required_contexts:
+          - ci/circleci
+          - security/brakeman
+    YAML
+
+    allow(github).to receive(:contents).and_return(config)
 
     expect(slack).to receive(:direct_message).with \
       slack_accounts(:david_baxterthehacker),
@@ -206,10 +264,17 @@ RSpec.feature 'Auto Deployment' do
   end
 
   scenario 'receiving a `failed` and `errored` status event' do
-    repo = Repository.with_name('baxterthehacker/public-repo')
-    environment = repo.environment('production')
-    environment.required_contexts = ['ci/circleci', 'security/brakeman']
-    environment.configure_auto_deploy('refs/heads/master')
+    config = <<-YAML.strip_heredoc
+    environments:
+      production:
+        continuous_delivery:
+          ref: refs/heads/master
+          required_contexts:
+          - ci/circleci
+          - security/brakeman
+    YAML
+
+    allow(github).to receive(:contents).and_return(config)
 
     expect(slack).to receive(:direct_message).with \
       slack_accounts(:david_baxterthehacker),
@@ -245,10 +310,17 @@ RSpec.feature 'Auto Deployment' do
   end
 
   scenario 'receiving a new `push` event for a new HEAD of the ref when there is a previous auto deployment' do
-    repo = Repository.with_name('baxterthehacker/public-repo')
-    environment = repo.environment('production')
-    environment.required_contexts = ['ci/circleci', 'security/brakeman']
-    environment.configure_auto_deploy('refs/heads/master')
+    config = <<-YAML.strip_heredoc
+    environments:
+      production:
+        continuous_delivery:
+          ref: refs/heads/master
+          required_contexts:
+          - ci/circleci
+          - security/brakeman
+    YAML
+
+    allow(github).to receive(:contents).and_return(config)
 
     commits = {
       # Commit #1
@@ -326,19 +398,11 @@ RSpec.feature 'Auto Deployment' do
   end
 
   scenario 'receiving a `push` event for a deleted branch' do
-    repo = Repository.with_name('baxterthehacker/public-repo')
-    environment = repo.environment('production')
-    environment.configure_auto_deploy('refs/heads/master')
-
     expect(github).to_not receive(:create_deployment)
     push_event 'secret', deleted: true, head_commit: nil
   end
 
   scenario 'receiving a `push` event for a fork' do
-    repo = Repository.with_name('baxterthehacker/public-repo')
-    environment = repo.environment('production')
-    environment.configure_auto_deploy('refs/heads/master')
-
     expect(github).to_not receive(:create_deployment)
     push_event 'secret', repository: { fork: true }
   end

--- a/spec/fixtures/repositories.yml
+++ b/spec/fixtures/repositories.yml
@@ -2,3 +2,4 @@
   name: 'baxterthehacker/public-repo'
   github_secret: secret
   installation_id: 1234
+  raw_config: "---\n"

--- a/spec/models/environment_spec.rb
+++ b/spec/models/environment_spec.rb
@@ -99,4 +99,22 @@ RSpec.describe Environment, type: :model do
       end
     end
   end
+
+  describe '#match_name' do
+    context 'when the repository has a config set' do
+      it 'returns the correct value' do
+        repo = Repository.with_name('acme-inc/api')
+        repo.configure! <<-YAML
+environments:
+  production:
+    aliases: [prod]
+YAML
+
+        environment = Environment.new(name: 'production', repository: repo)
+        expect(environment.match_name?('production')).to eq true
+        expect(environment.match_name?('prod')).to eq true
+        expect(environment.match_name?('pro')).to eq false
+      end
+    end
+  end
 end

--- a/spec/slashdeploy/config_spec.rb
+++ b/spec/slashdeploy/config_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe SlashDeploy::Config do
+  describe '#from_yaml' do
+    it 'loads a config from yaml' do
+      config = described_class.from_yaml <<-YAML
+environments:
+  staging:
+    aliases:
+    - stage
+  production:
+    aliases:
+    - prod
+    continuous_delivery:
+      ref: ref/heads/master
+YAML
+
+      expect(config.environments.length).to eq 2
+      expect(config.environments["staging"].aliases).to eq ["stage"]
+      expect(config.environments["production"].continuous_delivery.ref).to eq "ref/heads/master"
+    end
+  end
+end


### PR DESCRIPTION
Closes https://github.com/remind101/slashdeploy/issues/94
Fixes https://github.com/remind101/slashdeploy/issues/50

Since the move to a GitHub Integration, it makes it easy to support configuring a repositories known environments (and continuous delivery settings), via a file in the root of the repository, similar to something like `.circleci` or `.travis.yml`.

With this change, you can now add a `.slashdeploy.yml` to the root of a repositories default branch, and SlashDeploy will use that as it's source for determining what environments can be deployed to.

Here's a simple example that configures two environments, one in which we continously deliver the "master" branch to:

```yaml
---
production:
  
  # Allows us to reference this using "production" or a short alias, "prod".
  aliases:
    - prod

  # Enable continuous delivery for this environment.
  continuous_delivery:
    # You can specify any git "ref" (tag, branch, etc) to auto deploy when
    # pushed to.
    ref: refs/heads/master

    # If you want to only deploy when a set of GitHub commit statuses are
    # passing, you can configure those here. If none are provided, SlashDeploy
    # will deploy when new commits are pushed to the git ref.
    required_contexts:
      - ci/circleci

staging:
  aliases:
    - stage
```

I think this is a big improvement over what we had before (basically nothing), and better than having some kind of UI to do the configuration.