### PR TITLE
Deal with replayed (rebased or rewound) git sha

### DIFF
--- a/app/models/auto_deployment.rb
+++ b/app/models/auto_deployment.rb
@@ -5,6 +5,12 @@ class AutoDeployment < ActiveRecord::Base
   belongs_to :user
   has_many :statuses, primary_key: :sha, foreign_key: :sha
 
+  # there may be only one AutoDeployment per environment + sha.
+  validates :sha, uniqueness: {
+    scope: :environment,
+    message: "there may be only one AutoDeployment per environment + sha."
+  }
+
   # Deployment is waiting on required commit statuses to pass.
   STATE_PENDING = :pending
   # All required commit statuses are passing, and the deployment is ready to be deployed.

--- a/config/database.yml
+++ b/config/database.yml
@@ -15,6 +15,7 @@ default: &default
 development:
   <<: *default
   database: slashdeploy_development
+  port: 5432
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
@@ -22,3 +23,4 @@ development:
 test:
   <<: *default
   database: slashdeploy_test
+  port: 5432

--- a/lib/slashdeploy/service.rb
+++ b/lib/slashdeploy/service.rb
@@ -34,7 +34,8 @@ module SlashDeploy
     #
     # Returns an AutoDeployment.
     def create_auto_deployment(environment, sha, user)
-      auto_deployment = environment.auto_deployments.create! user: user, sha: sha
+      auto_deployment = environment.auto_deployments.create user: user, sha: sha
+      return auto_deployment unless auto_deployment.valid?
       state = auto_deployment.state
       case state
       when AutoDeployment::STATE_READY


### PR DESCRIPTION
If a push event from github would trigger an `auto_deployment`, but an
`AutoDeployment` already exists, log a message and return without creating
a duplicate `AutoDeployment`.

The `AutoDeployment` model is guarded by a foreign key constraint on the
`sha `+ `environment` fields so this bug fix simply prevents an exception from firing
and provides a more useful log message.

fixes #87

	modified:   CONTRIBUTING.md
	modified:   app/github/push_event.rb
	modified:   config/database.yml
	modified:   lib/slashdeploy/service.rb