### PR TITLE
Sidekiq Deployment Watchdog Worker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,9 @@ gem 'sass'
 gem 'faraday', '0.9.1'
 gem 'faraday_middleware'
 
+# async worker.
+gem 'sidekiq'
+
 # Visibility
 gem 'rollbar', '~> 2.8.0'
 gem 'lograge'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,7 @@ GEM
       execjs
     coffee-script-source (1.10.0)
     concurrent-ruby (1.0.5)
+    connection_pool (2.2.1)
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     crass (1.0.3)
@@ -174,6 +175,8 @@ GEM
     public_suffix (2.0.5)
     puma (2.16.0)
     rack (1.6.9)
+    rack-protection (2.0.1)
+      rack
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.7.1)
@@ -203,6 +206,7 @@ GEM
     rainbow (2.2.2)
       rake
     rake (12.3.0)
+    redis (4.0.1)
     rollbar (2.8.3)
       multi_json
     rspec-activemodel-mocks (1.0.1)
@@ -245,6 +249,11 @@ GEM
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
     sexp_processor (4.6.1)
+    sidekiq (5.1.1)
+      concurrent-ruby (~> 1.0)
+      connection_pool (~> 2.2, >= 2.2.0)
+      rack-protection (>= 1.5.0)
+      redis (>= 3.3.5, < 5)
     simplecov (0.11.2)
       docile (~> 1.1.0)
       json (~> 1.8)
@@ -325,6 +334,7 @@ DEPENDENCIES
   rspec-rails (~> 3.0)
   rubocop (~> 0.49.0)
   sass
+  sidekiq
   spring
   turbolinks
   uglifier (>= 1.3.0)

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,5 @@
-web: bundle exec puma -C config/puma.rb
+web:
+  command: bundle exec puma -C config/puma.rb
+
+worker:
+  command: bundle exec sidekiq -c 2 -q deployment_watchdog

--- a/app/messages/auto_deployment_stuck_pending_message.rb
+++ b/app/messages/auto_deployment_stuck_pending_message.rb
@@ -1,0 +1,10 @@
+class AutoDeploymentStuckPendingMessage < SlackMessage
+  values do
+    attribute :account, SlackAccount
+    attribute :auto_deployment, AutoDeployment
+  end
+
+  def to_message
+    Slack::Message.new text: text
+  end
+end

--- a/app/views/messages/auto_deployment_stuck_pending.text.erb
+++ b/app/views/messages/auto_deployment_stuck_pending.text.erb
@@ -1,0 +1,1 @@
+:sadparrot: <@<%= @account.id %>>. There was an issue with <%= @auto_deployment.environment.repository %>@<%= @auto_deployment.sha[0...7] %> to *<%= @auto_deployment.environment %>*. Some of the required commit status contexts appear hung: <%= @auto_deployment.pending_statuses.map { |s| "*#{s.context}*" }.to_sentence %>

--- a/app/workers/deployment_watchdog_worker.rb
+++ b/app/workers/deployment_watchdog_worker.rb
@@ -1,0 +1,28 @@
+class DeploymentWatchdogWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: 'deployment_watchdog'
+
+  # default time to wait until our worker wakes up.
+  DEFAULT_DELAY = 1.hour
+
+  # create a class method to hardcode how we want to schedule this worker.
+  def self.schedule(auto_deployment_id)
+    self.perform_in(DEFAULT_DELAY, auto_deployment_id)
+  end
+
+  def perform(auto_deployment_id)
+    auto_deployment = AutoDeployment.find(auto_deployment_id)
+    # an inactive auto_deployment was either deployed, or superceded
+    # by another auto_deployment. Either way we exit without notifying.
+    return logger.debug "auto_deployment id #{auto_deployment.id} is inactive which means it was already deployed or superceded." if auto_deployment.inactive?
+    if auto_deployment.pending?
+      logger.info "There was an issue with auto_deployment id #{auto_deployment.id}. Seems to be hung on #{auto_deployment.pending_statuses}"
+      SlashDeploy.service.direct_message(
+        auto_deployment.slack_account,
+        AutoDeploymentStuckPendingMessage,
+        auto_deployment: auto_deployment,
+        account: auto_deployment.slack_account
+      )
+    end
+  end
+end

--- a/lib/slashdeploy/service.rb
+++ b/lib/slashdeploy/service.rb
@@ -45,6 +45,8 @@ module SlashDeploy
           auto_deployment.slack_account, \
           AutoDeploymentCreatedMessage, \
           auto_deployment: auto_deployment
+        # schedule Deployment Watchdog to check up on this AutoDeployment.
+        DeploymentWatchdogWorker.schedule(auto_deployment.id)
       else
         fail "Unhandled #{state} state"
       end

--- a/spec/support/sidekiq.rb
+++ b/spec/support/sidekiq.rb
@@ -1,0 +1,4 @@
+# load sidekiq testing for our tests and set testing mode to fake.
+# Fake uses a queue object instead of talking to a real redis queue.
+require 'sidekiq/testing'
+Sidekiq::Testing.fake!


### PR DESCRIPTION
High Level Overview
===================

* Adds sidekiq to project
* Schedules a Deployment watchdog to run 30 seconds after creating the AutoDeployment

Heroku
========

Logged into UI and added redis as a "hobby dev" for now. Once provisioned, you can see the new redis url with the following command:

```
heroku config -a slashdeploy
```

Sidekiq expects you to set the following:

```
heroku config:set REDIS_PROVIDER=REDIS_URL -a slashdeploy
```
reference: https://github.com/mperham/sidekiq/wiki/Using-Redis#using-an-env-variable

Files Changed
===============

	modified:   Gemfile
	modified:   Gemfile.lock
	modified:   Procfile
	new file:   app/messages/auto_deployment_stuck_pending_message.rb
	modified:   app/models/auto_deployment.rb
	new file:   app/workers/deployment_watchdog_worker.rb
	new file:   bin/worker_deployment_watchdog
	modified:   lib/slashdeploy/service.rb
	modified:   spec/features/auto_deploy_spec.rb