### PR TITLE
SlashDeploy /teams page.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,6 +14,10 @@ class ApplicationController < ActionController::Base
   end
   helper_method :signed_in?
 
+  def authenticate!
+    redirect_to login_path unless signed_in?
+  end
+
   private
 
   def warden

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,0 +1,10 @@
+class TeamsController < ApplicationController
+  before_action :authenticate!
+  def index
+    @slack_teams = current_user.slack_teams
+    # get a list of slack team objects who have slack_accounts with locks.
+    # @slack_teams_with_locks = current_user.slack_teams.includes(
+    #   slack_accounts: [:locks]
+    # )
+  end
+end

--- a/app/github/deployment_status_event.rb
+++ b/app/github/deployment_status_event.rb
@@ -16,6 +16,6 @@ class DeploymentStatusEvent < GitHubEventHandler
   end
 
   def user
-    @user ||= User.find_by_github_account_id(event['deployment']['creator']['id'])
+    @user ||= User.find_by_github(event['deployment']['creator']['id'])
   end
 end

--- a/app/models/github_account.rb
+++ b/app/models/github_account.rb
@@ -16,4 +16,8 @@ class GitHubAccount < ActiveRecord::Base
     update_attributes! self.class.attributes_from_auth_hash(auth_hash).except(:id)
     self
   end
+
+  def username
+    login
+  end
 end

--- a/app/models/slack_account.rb
+++ b/app/models/slack_account.rb
@@ -40,6 +40,10 @@ class SlackAccount < ActiveRecord::Base
       slack_team: team
   end
 
+  def username
+    user_name
+  end
+
   def team_id
     slack_team.id
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,6 +31,24 @@
       <div class="navbar-collapse collapse" id="navbar-collapse-9">
         <ul class="nav navbar-nav">
           <li class="<%= 'active' if current_page?(documentation_path) %>"><%= link_to 'Documentation', documentation_path %></li>
+          <% if current_user.present? %>
+            <li class="<%= 'active' if current_page?(teams_path) %>"><%= link_to 'Teams', teams_path %></li>
+          <% end %>
+        </ul>
+
+        <ul class="nav navbar-nav navbar-right">
+        <% if current_user.present? %>
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <img src="https://github.com/<%= current_user.username =%>.png?size=128" style="width: 18px; margin-right: 10px;"/> <%= current_user.username =%>
+            </a>
+              <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+                <%= link_to 'Logout', logout_path, method: :post %>
+              </div>
+          </li>
+        <% else %>
+            <li><%= link_to 'Login', login_path %></li>
+        <% end %>
         </ul>
         <!--<form class="navbar-form navbar-right" role="form">
           <button type="submit" class="btn btn-success">Sign in</button>

--- a/app/views/teams/index.html.erb
+++ b/app/views/teams/index.html.erb
@@ -1,0 +1,30 @@
+<div id="intro">
+  <h3>
+  SlashDeploy Teams
+  <small>
+  locks, statuses, and more
+  </small>
+  </h3>
+  <% @slack_teams.each do |slack_team| %>
+    <hr>
+    <h6>
+    Slack Team: <a href="https://<%= slack_team.domain =%>.slack.com" target="_blank"><%= slack_team.domain %></a>
+    </h6>
+    <% slack_team.slack_accounts.each do |slack_account| %>
+      <% slack_account.user.locks.active.each do |lock| %>
+        <div>
+          <span class="fui-lock"></span>
+          <code><%= lock.environment =%></code>
+          <a href="https://github.com/<%= lock.environment.repository =%>" target="_blank"><%= lock.environment.repository =%></a>
+          <div class="small" style="opacity: .75; padding-left: 24px;">
+            <img src="https://github.com/<%= lock.user.username =%>.png?size=18" />
+            <a href="https://github.com/<%= lock.user.username =%>" target="_blank"><%= lock.user.username =%></a>
+            locked
+            <%= time_ago_in_words(lock.created_at) %> ago
+          </div>
+        </div>
+        <br/>
+      <% end %>
+    <% end %>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   post '/slack/install' => 'slack#early_access', as: :early_access
 
   get '/login' => redirect('/auth/slack'), as: :login
+
   post '/logout' => 'sessions#destroy', as: :logout
 
   # Docs
@@ -28,6 +29,8 @@ Rails.application.routes.draw do
     handle :deployment_status, DeploymentStatusEvent
   end
   post '/', to: github_webhooks, constraints: Hookshot.constraint
+
+  get '/teams' => 'teams#index', as: :teams
 
   root 'pages#index'
   # The priority is based upon order of creation: first created -> highest priority.

--- a/spec/features/commands_spec.rb
+++ b/spec/features/commands_spec.rb
@@ -34,7 +34,7 @@ RSpec.feature 'Slash Commands' do
       slack_team: slack_teams(:acme)
     )
 
-    command '/deploy help', as: account
+    command '/deploy acme-inc/api to prod', as: account
 
     OmniAuth.config.mock_auth[:jwt] = OmniAuth::AuthHash.new(
       provider: 'jwt',


### PR DESCRIPTION
Proof of concept of SlashDeploy /teams page.

Also ads a user interface for logging in and out.

Refactors a single way of getting User object from Github ID

```
	new file:   app/controllers/teams_controller.rb
	modified:   app/github/deployment_status_event.rb
	modified:   app/models/user.rb
	modified:   app/views/layouts/application.html.erb
	new file:   app/views/teams/index.html.erb
	modified:   config/routes.rb
	modified:   spec/features/commands_spec.rb
```

![slashdeploy-teams](https://user-images.githubusercontent.com/909098/38276679-a330be3e-374a-11e8-82fd-e1752c5a816a.gif)