### PR TITLE
Make sure profile pics always have a size defined by us.

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -40,14 +40,17 @@
         <% if current_user.present? %>
           <li class="nav-item dropdown">
             <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            <img src="https://github.com/<%= current_user.username =%>.png?size=128" style="width: 18px; margin-right: 10px;"/> <%= current_user.username =%>
+              <img src="https://github.com/<%= current_user.username =%>.png?size=128" style="width: 18px; margin-right: 8px;"/>
+              <%= current_user.username =%> <span class="caret"></span>
             </a>
-              <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-                <%= link_to 'Logout', logout_path, method: :post %>
-              </div>
+              <ul class="dropdown-menu" style="margin-top: 0px;">
+                <li><%= link_to 'Your Teams', teams_path %></li>
+                <li role="separator" class="divider"></li>
+                <li><%= link_to 'Log out', logout_path, method: :post %></li>
+              </ul>
           </li>
         <% else %>
-            <li><%= link_to 'Login', login_path %></li>
+            <li><%= link_to 'Log in', login_path %></li>
         <% end %>
         </ul>
         <!--<form class="navbar-form navbar-right" role="form">

--- a/app/views/teams/index.html.erb
+++ b/app/views/teams/index.html.erb
@@ -17,7 +17,7 @@
           <code><%= lock.environment =%></code>
           <a href="https://github.com/<%= lock.environment.repository =%>" target="_blank"><%= lock.environment.repository =%></a>
           <div class="small" style="opacity: .75; padding-left: 24px;">
-            <img src="https://github.com/<%= lock.user.username =%>.png?size=18" />
+            <img src="https://github.com/<%= lock.user.username =%>.png?size=128" style="width: 18px; margin-right: 8px;" />
             <a href="https://github.com/<%= lock.user.username =%>" target="_blank"><%= lock.user.username =%></a>
             locked
             <%= time_ago_in_words(lock.created_at) %> ago


### PR DESCRIPTION
If a user only has a gravatar or default avatar or whatever gthub uses,
the size parameter is ignored. because of this we always need to set an
image width as well as pass the size parameter to make sure our layout
doesn't get messed up.

	modified:   app/views/layouts/application.html.erb
	modified:   app/views/teams/index.html.erb