### PR TITLE
Secure default for auth requirement

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,10 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
+  # By default, all actions should require authentication. Individual actions
+  # can opt-out using `skip_before_action`.
+  before_action :authenticate!
+
   def current_user
     warden.user
   end

--- a/app/controllers/documentation_controller.rb
+++ b/app/controllers/documentation_controller.rb
@@ -1,4 +1,6 @@
 class DocumentationController < ApplicationController
+  skip_before_action :authenticate!
+
   def index
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,7 @@
 # Controller for static pages
 class PagesController < ApplicationController
+  skip_before_action :authenticate!
+
   def index
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,6 +1,8 @@
 class SessionsController < ApplicationController
   skip_before_filter :verify_authenticity_token
 
+  skip_before_action :authenticate!
+
   def failure
     render text: 'Authentication failed'
   end

--- a/app/controllers/slack_controller.rb
+++ b/app/controllers/slack_controller.rb
@@ -2,6 +2,8 @@
 class SlackController < ApplicationController
   skip_before_filter :verify_authenticity_token
 
+  skip_before_action :authenticate!
+
   def install
     redirect_to oauth_path(:slack, scope: 'bot,commands') unless beta?
   end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,5 +1,4 @@
 class TeamsController < ApplicationController
-  before_action :authenticate!
   def index
     @slack_teams = current_user.slack_teams
     # get a list of slack team objects who have slack_accounts with locks.


### PR DESCRIPTION
Just following up on https://github.com/remind101/slashdeploy/pull/108#discussion_r179905802. This makes auth required by default, and controllers need to opt-out.