### PR TITLE
This fixes issue #116

### DIFF
--- a/app/actions/slash_actions.rb
+++ b/app/actions/slash_actions.rb
@@ -23,6 +23,9 @@ class SlashActions
     account = env['account']
     user = account.user
 
+    # User needs a Github account, so bubble MissingGitHubAccount if missing.
+    user.github_account
+
     scope = {
       person: { id: user.id, username: user.username }
     }

--- a/app/commands/slash_commands.rb
+++ b/app/commands/slash_commands.rb
@@ -46,6 +46,9 @@ class SlashCommands
     account = env['account']
     user = account.user
 
+    # User needs a Github account, so bubble MissingGitHubAccount if missing.
+    user.github_account
+
     scope = {
       person: { id: user.id, username: user.username }
     }

--- a/spec/features/commands_spec.rb
+++ b/spec/features/commands_spec.rb
@@ -34,13 +34,19 @@ RSpec.feature 'Slash Commands' do
       slack_team: slack_teams(:acme)
     )
 
-    command '/deploy acme-inc/api to prod', as: account
+    # This is the first time this user ran a slash deploy command.
+    # This user does not have an associated Github account so
+    # we bubble and resue MissingGitHubAccount. During the rescue we
+    # send a slack notification to the user with a link to install slashdeploy
+    # as an oauth app on their github user.
+    command '/deploy help', as: account
 
     OmniAuth.config.mock_auth[:jwt] = OmniAuth::AuthHash.new(
       provider: 'jwt',
       uid: User.find_by_slack('UABCD').id
     )
 
+    # simulate clicking the oauth link.
     expect do
       visit command_response.text.match(%r{^.*(/auth/jwt/callback\?jwt=.*?)\|.*$})[1]
     end.to_not change { User.count }


### PR DESCRIPTION
Our slash commands all expect a User object with an associated GithubAccount and SlackAccount.

We created a regression when we changed how we implemented
`User#username` such that it no longer raises MissingGitHubAccount.

As a result, the super class of our slash commands no longer triggered
this exception if a User object did not have an associated
GithubAccount.

As a result we never send the user a login link.

To fix this regression I make the superclass call User#github_account
method which triggers MissingGitHubAccount so that it can be rescued by
our authentication routines.

	modified:   app/actions/slash_actions.rb
	modified:   app/commands/slash_commands.rb
	modified:   spec/features/commands_spec.rb