### PR TITLE
allow aliases in config files

### DIFF
--- a/lib/slashdeploy/config.rb
+++ b/lib/slashdeploy/config.rb
@@ -40,7 +40,8 @@ module SlashDeploy
     #
     # Returns Config.
     def self.from_yaml(yaml)
-      new Psych.safe_load(yaml)
+      # disable arbirtary class deserialization but allow aliases
+      new Psych.safe_load(yaml, [], [], true)
     end
   end
 end


### PR DESCRIPTION
we'd like to be able to use aliases in the slashdeploy.yml files, like:
```
environments:
  production: 
    aliases:
      - prod
    continuous_delivery: &cd
      ref: refs/heads/master
      required_contexts:
        - "ci/circleci: docker_image"
        - "ci/circleci: bundle_audit_check"
        - "ci/circleci: cucumber"
        - "ci/circleci: prevent_unsafe_migrations"
        - "ci/circleci: rspec"
  staging:
    continuous_delivery:
      <<: *cd
    aliases:
      - stage
```

However, `safe_load` doesnt allow aliases by default:
```
Psych::BadAlias: Unknown alias: cd
```

Change it to let us use them