### PR TITLE
Fixes: Commit checks skipped when deploying to an environment with autodeploys set up

### DIFF
--- a/app/commands/deploy_command.rb
+++ b/app/commands/deploy_command.rb
@@ -14,6 +14,7 @@ class DeployCommand < BaseCommand
           user,
           env,
           params['ref'],
+          skip_cd_check: params['skip_cd_check'] || params['force'],
           force: params['force']
         )
 
@@ -47,9 +48,12 @@ class DeployCommand < BaseCommand
           unlock_action: unlock_action
         respond env.in_channel?, m
       rescue SlashDeploy::EnvironmentAutoDeploys
+        # Message user on slack and ask if we should bypass CD and deploy
+        # this commit directly into this environment. Alter params with
+        # skip_cd_check = true in preparation if user clicks yes.
         message_action = slashdeploy.create_message_action(
           DeployAction,
-          params.merge('force' => true)
+          params.merge('skip_cd_check' => true)
         )
         Slash.reply AutoDeploymentConfiguredMessage.build \
           environment: env,

--- a/lib/slashdeploy/service.rb
+++ b/lib/slashdeploy/service.rb
@@ -87,10 +87,12 @@ module SlashDeploy
     # ref         - A String git ref. If none is provided, defaults to the
     #               default ref.
     # options     - A Hash of extra options.
-    #               :force       - "force" the deployment, ignoring commit
-    #                               status contexts.
-    #               :strong_lock - If set to true, even the user that locked it
-    #                              won't be able to deploy.
+    #               :skip_cd_check - bypass continuous deployment, release
+    #                                specified commit to environment.
+    #               :force         - "force" the deployment, ignoring commit
+    #                                status contexts.
+    #               :strong_lock   - If set to true, even the user that locked
+    #                                it won't be able to deploy.
     #
     # Returns a DeploymentResponse.
     def create_deployment(user, environment, ref = nil, options = {})
@@ -99,7 +101,7 @@ module SlashDeploy
       req = deployment_request(environment, ref, force: options[:force])
 
       # Check if the environment we're deploying to is configured for auto deployments.
-      fail EnvironmentAutoDeploys if environment.auto_deploy_enabled? && !options[:force]
+      fail EnvironmentAutoDeploys if environment.auto_deploy_enabled? && !options[:skip_cd_check]
 
       # Check if the environment we're deploying to is locked.
       lock = environment.active_lock


### PR DESCRIPTION

Commit checks skipped when deploying to an environment with autodeploys set up

https://github.com/remind101/slashdeploy/issues/123