### PR TITLE
Lock Nag Worker

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: bundle exec puma -C config/puma.rb
-worker: bundle exec sidekiq -c 2 -q auto_deployment_watchdog -q github_deployment_watchdog
+worker: bundle exec sidekiq -c 2 -q auto_deployment_watchdog -q github_deployment_watchdog -q lock_nag

--- a/app/messages/lock_nag_message.rb
+++ b/app/messages/lock_nag_message.rb
@@ -1,0 +1,24 @@
+class LockNagMessage < SlackMessage
+  values do
+    attribute :lock, Lock
+    attribute :account, SlackAccount
+    attribute :message_action, MessageAction
+  end
+
+  def to_message
+    Slack::Message.new text: text(locker: locker), attachments: [
+      Slack::Attachment.new(
+        title: 'Unlock?',
+        callback_id: message_action.callback_id,
+        color: '#3AA3E3',
+        actions: SlackMessage.confirmation_actions
+      )
+    ]
+  end
+
+  private
+
+  def locker
+    lock.slack_account
+  end
+end

--- a/app/models/lock.rb
+++ b/app/models/lock.rb
@@ -5,6 +5,10 @@ class Lock < ActiveRecord::Base
 
   scope :active, -> { where(active: true) }
 
+  def inactive?
+    !active
+  end
+
   def unlock!
     update_attributes!(active: false)
   end

--- a/app/views/messages/lock_nag.text.erb
+++ b/app/views/messages/lock_nag.text.erb
@@ -1,0 +1,2 @@
+:lock: :alarm_lock: Hey <@<%= @account.id %>>, Did you forget to unlock <%= @lock.environment.repository %>@<%= @lock.environment %>?
+I'm not able to perform any AutoDeployments configured in `.slashdeploy.yml` until the lock is released.

--- a/app/workers/lock_nag_worker.rb
+++ b/app/workers/lock_nag_worker.rb
@@ -1,0 +1,41 @@
+class LockNagWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: 'lock_nag'
+
+  # default time to wait until our worker wakes up.
+  DEFAULT_DELAY = 3.day
+
+  # create a class method to hardcode how we want to schedule this worker.
+  def self.schedule(lock_id)
+    self.perform_in(DEFAULT_DELAY, lock_id)
+  end
+
+  def perform(lock_id)
+    lock = Lock.find(lock_id)
+
+    # an inactive lock does not need to be processed.
+    return logger.debug "lock id (#{lock.id}) is already inactive, skipping." if lock.inactive?
+
+    logger.info "Nagging user about lock id (#{lock.id}) and rescheduling another lock nag for the future."
+
+    # reschedule another nag.
+    self.class.schedule(lock.id)
+
+    # create a message_action to let the user click a button to unlock
+    # the environment from the nag message itself.
+    message_action = SlashDeploy.service.create_message_action(
+      UnlockAction,
+      repository: lock.repository.name,
+      environment: lock.environment.name,
+    )
+
+    # send the user a nagging direct message with a button for redemption.
+    SlashDeploy.service.direct_message(
+      lock.slack_account,
+      LockNagMessage,
+      lock: lock,
+      account: lock.slack_account,
+      message_action:  message_action,
+    )
+  end
+end

--- a/lib/slashdeploy/service.rb
+++ b/lib/slashdeploy/service.rb
@@ -143,6 +143,12 @@ module SlashDeploy
       stolen = lock
       lock = environment.lock! user, options[:message]
 
+      # I'm not sure why, but sometimes lock can be nil?
+      if lock
+        # schedule an LockNag Watchdog to check up on this Lock.
+        LockNagWorker.schedule(lock.id)
+      end
+
       LockResponse.new \
         lock: lock,
         stolen: stolen


### PR DESCRIPTION
Add a new Lock Nag Worker to notify users who hold locks for over 3 days.

	new file:   app/messages/lock_nag.rb
	modified:   app/models/environment.rb
	modified:   app/models/lock.rb
	new file:   app/views/messages/lock_nag.text.erb
	new file:   app/workers/lock_nag_worker.rb
	modified:   lib/slashdeploy/service.rb