### PR TITLE
WIP: Allow end user to configure default environment from .slashdeploy.yml

### DIFF
--- a/app/models/environment.rb
+++ b/app/models/environment.rb
@@ -53,8 +53,13 @@ class Environment < ActiveRecord::Base
   # or one of it's aliases.
   def match_name?(name)
     return true if self.name == name
-    return true if config.aliases.include?(name)
+    return true if aliases.include?(name)
     false
+  end
+
+  # Returns true if 'default' in aliases, else false.
+  def is_default?
+    aliases.include?('default')
   end
 
   # Returns the aliases for this environment.

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -13,14 +13,16 @@ class Repository < ActiveRecord::Base
     find_or_create_by(name: name)
   end
 
-  # Finds the associated environment with the given name, creating it if
-  # necessary. If name is nil, returns the default environment, if the
-  # repository has a default environment set.
+  # Get or create associated environment with the given name.
+  # If given name is nil, return the default environment if configured.
+  # If default environment is not configured, this method will return nil.
   def environment(name = nil)
-    if config?
-      known_environments.find { |env| env.match_name?(name) }
+    if name == nil
+      return default_environment
+    elsif config?
+      return known_environments.find { |env| env.match_name?(name) }
     else
-      environments.with_name(name || default_environment)
+      return environments.with_name(name)
     end
   end
 
@@ -36,7 +38,8 @@ class Repository < ActiveRecord::Base
 
   # The default environment to deploy to when one is not specified.
   def default_environment
-    super.presence
+    # filter (select) the default environment and pop (shift) it out.
+    known_environments.select { |env| env.is_default? }.shift
   end
 
   # Returns the environment that's configured to auto deploy this ref.

--- a/app/views/messages/environments.text.erb
+++ b/app/views/messages/environments.text.erb
@@ -2,7 +2,8 @@
 I don't know about any environments for <%= @repository %>. For details about configuring environments, see <https://slashdeploy.io/docs>.
 <% else %>
 I know about these environments for <%= @repository %>:
-  <% @repository.known_environments.each do |environment| %>
-* <%= environment.name %>
-  <% end %>
+<% @repository.known_environments.each do |environment| %>
+ * <%= environment.name %><% if environment.is_default? %> (default)<% end %>
+<% end %>
+<% if @repository.default_environment == nil %>No default environment set, for details see <https://slashdeploy.io/docs>.<% end %>
 <% end %>

--- a/spec/features/commands_spec.rb
+++ b/spec/features/commands_spec.rb
@@ -446,7 +446,8 @@ RSpec.feature 'Slash Commands' do
     command '/deploy where acme-inc/api', as: slack_accounts(:david)
     expect(command_response.message).to eq Slack::Message.new(text: <<-TEXT.strip_heredoc.strip)
     I know about these environments for acme-inc/api:
-    * staging
+     * staging
+    No default environment set, for details see <https://slashdeploy.io/docs>. 
     TEXT
 
     command '/deploy where baxterthehacker/public-repo', as: slack_accounts(:david)
@@ -461,7 +462,8 @@ RSpec.feature 'Slash Commands' do
     command '/deploy where baxterthehacker/public-repo', as: slack_accounts(:david)
     expect(command_response.message).to eq Slack::Message.new(text: <<-TEXT.strip_heredoc.strip)
     I know about these environments for baxterthehacker/public-repo:
-    * production
+     * production
+    No default environment set, for details see <https://slashdeploy.io/docs>.
     TEXT
   end
 
@@ -480,27 +482,33 @@ RSpec.feature 'Slash Commands' do
   end
 
   scenario 'trying to /deploy with no environment, when the repository does not have a default' do
-    expect do
-      command '/deploy acme-inc/api@master', as: slack_accounts(:david)
-    end.to_not change { deployment_requests }
-    expect(command_response.message).to eq Slack::Message.new(
-      text: 'Oops! We had a problem running that command for you.',
-      attachments: [
-        Slack::Attachment.new(color: '#f00', fields: [
-          Slack::Attachment::Field.new(title: 'environment name', value: "can't be blank")
-        ])
-      ]
-    )
-  end
-
-  scenario 'trying to /deploy an environment that is configured to auto deploy' do
     repo = Repository.with_name('acme-inc/api')
-    repo.update_attributes! default_environment: 'production'
     environment = repo.environment('production')
+    # do not set default environment.
+    environment.aliases = ['prod']
     environment.configure_auto_deploy('refs/heads/master')
 
     expect do
       command '/deploy acme-inc/api@master', as: slack_accounts(:david)
+    end.to_not change { deployment_requests }
+
+    expect(command_response.message).to eq Slack::Message.new(text: <<-TEXT.strip_heredoc.strip)
+    I know about these environments for acme-inc/api:
+     * production
+    No default environment set, for details see <https://slashdeploy.io/docs>.
+    TEXT
+
+  end
+
+  scenario 'trying to /deploy with no environment, when the repository has a default' do
+    repo = Repository.with_name('acme-inc/api')
+    environment = repo.environment('production')
+    # set default environment.
+    environment.aliases = ['prod', 'default']
+    environment.configure_auto_deploy('refs/heads/master')
+
+    expect do
+      command '/deploy acme-inc/api', as: slack_accounts(:david)
     end.to_not change { deployment_requests }
 
     callback_id = command_response.message.attachments[0].callback_id
@@ -518,14 +526,37 @@ RSpec.feature 'Slash Commands' do
     end.to change { deployment_requests.count }.by(1)
   end
 
-  scenario 'trying to /deploy an environment that is configured to auto deploy by action' do
+  scenario 'trying to /deploy that is configured to auto deploy' do
     repo = Repository.with_name('acme-inc/api')
-    repo.update_attributes! default_environment: 'production'
     environment = repo.environment('production')
     environment.configure_auto_deploy('refs/heads/master')
 
     expect do
-      command '/deploy acme-inc/api@master', as: slack_accounts(:david)
+      command '/deploy acme-inc/api@master to production', as: slack_accounts(:david)
+    end.to_not change { deployment_requests }
+
+    callback_id = command_response.message.attachments[0].callback_id
+    expect(command_response.message).to eq Slack::Message.new(text: 'acme-inc/api is configured to automatically deploy `refs/heads/master` to *production*.', attachments: [
+      Slack::Attachment.new(
+        title: 'Deploy anyway?',
+        callback_id: callback_id,
+        color: '#3AA3E3',
+        actions: SlackMessage.confirmation_actions
+      )
+    ])
+
+    expect do
+      command '/deploy acme-inc/api@master! to production', as: slack_accounts(:david)
+    end.to change { deployment_requests.count }.by(1)
+  end
+
+  scenario 'trying to /deploy an environment that is configured to auto deploy by action' do
+    repo = Repository.with_name('acme-inc/api')
+    environment = repo.environment('production')
+    environment.configure_auto_deploy('refs/heads/master')
+
+    expect do
+      command '/deploy acme-inc/api@master to production', as: slack_accounts(:david)
     end.to_not change { deployment_requests }
 
     callback_id = command_response.message.attachments[0].callback_id
@@ -546,12 +577,11 @@ RSpec.feature 'Slash Commands' do
 
   scenario 'trying to /deploy an environment that is configured to auto deploy by action but whose context checks are failing' do
     repo = Repository.with_name('acme-inc/api')
-    repo.update_attributes! default_environment: 'production'
     environment = repo.environment('production')
     environment.configure_auto_deploy('refs/heads/master')
 
     expect do
-      command '/deploy acme-inc/api@failing', as: slack_accounts(:david)
+      command '/deploy acme-inc/api@failing to production', as: slack_accounts(:david)
     end.to_not change { deployment_requests }
 
     callback_id = command_response.message.attachments[0].callback_id

--- a/spec/models/environment_spec.rb
+++ b/spec/models/environment_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe Environment, type: :model do
       expect(relation.count).to eq 1
       expect(relation.first.name).to eq 'production'
     end
+
   end
 
   describe '#in_channel' do
@@ -96,24 +97,6 @@ RSpec.describe Environment, type: :model do
 
         environment = Environment.new
         expect(environment.default_ref).to eq 'master'
-      end
-    end
-  end
-
-  describe '#match_name' do
-    context 'when the repository has a config set' do
-      it 'returns the correct value' do
-        repo = Repository.with_name('acme-inc/api')
-        repo.configure! <<-YAML
-environments:
-  production:
-    aliases: [prod]
-YAML
-
-        environment = Environment.new(name: 'production', repository: repo)
-        expect(environment.match_name?('production')).to eq true
-        expect(environment.match_name?('prod')).to eq true
-        expect(environment.match_name?('pro')).to eq false
       end
     end
   end


### PR DESCRIPTION
WIP: Allow end user to configure default environment from .slashdeploy.yml

	modified:   app/models/environment.rb
	modified:   app/models/repository.rb
	modified:   app/views/messages/environments.text.erb
	modified:   spec/features/commands_spec.rb
	modified:   spec/models/environment_spec.rb
	modified:   spec/models/repository_spec.rb