### PR TITLE
Setup default_environment from .slashdeploy.yml

### DIFF
--- a/app/models/environment.rb
+++ b/app/models/environment.rb
@@ -43,13 +43,18 @@ class Environment < ActiveRecord::Base
   # or one of it's aliases.
   def match_name?(name)
     return true if self.name == name
-    return true if config.aliases.include?(name)
+    return true if aliases.include?(name)
     false
   end
 
   # Returns the aliases for this environment.
   def aliases
     config.aliases
+  end
+
+  # Returns true if this environment is the default for this repository, else false.
+  def is_default?
+    self.name == repository.default_environment_name
   end
 
   # Checks if this environment is configured to automatically deploy the given ref.

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -13,11 +13,11 @@ class Repository < ActiveRecord::Base
     find_or_create_by(name: name)
   end
 
-  # Finds the associated environment with the given name, creating it if
-  # necessary. If name is nil, returns the default environment, if the
-  # repository has a default environment set.
+  # Get or create associated environment with the given name.
+  # If given name is nil, return the default environment if configured.
+  # If default environment is not configured, this method will return nil.
   def environment(name = nil)
-    name = default_environment unless name
+    name = default_environment_name unless name
     known_environments.find { |env| env.match_name?(name) }
   end
 
@@ -28,9 +28,16 @@ class Repository < ActiveRecord::Base
     config.environments.map { |name, _| environments.find_or_create_by!(name: name) }
   end
 
-  # The default environment to deploy to when one is not specified.
+  # The default environment name, if configured.
+  def default_environment_name
+    return nil unless config?
+    config.default_environment
+  end
+
+  # The default environment object, if configured.
   def default_environment
-    super.presence
+    return nil unless default_environment_name
+    environment(default_environment_name)
   end
 
   # Returns the environment that's configured to auto deploy this ref.

--- a/app/views/documentation/index.html.erb
+++ b/app/views/documentation/index.html.erb
@@ -49,31 +49,56 @@
     <p><code>/deploy acme-inc/api to staging</code></p>
     <p>When I'm done testing my changes, I can unlock the environment so others can deploy to it again.</p>
     <p><code>/deploy unlock staging on acme-inc/api</code></p>
+    <p>When I'm done for the day, I can release all my locks.
+    <p><code>/deploy unlock all</code></p>
 
     <hr />
 
+    <h5 id=".slashdeploy.yml">.slashdeploy.yml</h5>
+
+    <p>You may configure SlashDeploy for your project by putting a <code>.slashdeploy.yml</code> file in the root of your git repository.
+    <p>Here is a heavily commented <code>.slashdeploy.yml</code> example:
+      <pre>---
+# teach SlashDeploy which environment is default. optional.
+# used when environment is not passed to a `/deploy` command.
+default_environment: production
+
+# a document of available environments for this repository.
+environments:
+
+  # an environment named "production".
+  production:
+
+    # an optional list of aliases used to refer to the "production" environment.
+    aliases:
+      - prod
+
+  # another environment named "stage".
+  stage:
+    aliases:
+      - staging
+    </pre>
+
     <h5 id="continuous-delivery">Continuous Delivery</h5>
-    <p>You can configure SlashDeploy to automatically deploy a branch to an environment when you push code to GitHub or when a set of commit status contexts succeeds.</p>
-    <p>To configure CD, you add a <code>.slashdeploy.yml</code> file to the root of the repository. Here's an example config file that will automatically deploy the <code>master</code> branch to the <code>production</code> environment, once tests are passing on CircleCI:</p>
+    <p>You can configure SlashDeploy to automatically deploy a branch to an environment when you push code to GitHub.</p>
+    <p>If you utilize Github "Branch Protection Rules", you should likely use the same set of "Require status checks" under <code>required_context</code>.</p>
+    <p>This example <code>.slashdeploy.yml</code> file will automatically deploy the <code>master</code> branch to the <code>production</code> environment, once tests are passing on CircleCI:</p>
     <p>
       <pre>---
-production:
+environments:
+  production:
+
+    # Enable continuous delivery for this environment.
+    continuous_delivery:
+
+      # Specify any git "ref" (tag, branch, etc) to auto deploy when pushed to.
+      ref: refs/heads/master
   
-  # Allows us to reference this using "production" or a short alias, "prod".
-  aliases:
-    - prod
-
-  # Enable continuous delivery for this environment.
-  continuous_delivery:
-    # You can specify any git "ref" (tag, branch, etc) to auto deploy when
-    # pushed to.
-    ref: refs/heads/master
-
-    # If you want to only deploy when a set of GitHub commit statuses are
-    # passing, you can configure those here. If none are provided, SlashDeploy
-    # will deploy when new commits are pushed to the git ref.
-    required_contexts:
-      - ci/circleci</pre>
+      # To deploy only after a set of GitHub commit statuses pass,
+      # configure required_contexts (optional).
+      required_contexts:
+        - ci/circleci
+      </pre>
     </p>
 
     <hr />

--- a/app/views/messages/environments.text.erb
+++ b/app/views/messages/environments.text.erb
@@ -2,7 +2,8 @@
 I don't know about any environments for <%= @repository %>. For details about configuring environments, see <https://slashdeploy.io/docs>.
 <% else %>
 I know about these environments for <%= @repository %>:
-  <% @repository.known_environments.each do |environment| %>
-* <%= environment.name %>
-  <% end %>
+<% @repository.known_environments.each do |environment| %>
+ * <%= environment.name %><% if environment.is_default? %> (default)<% end %>
+<% end %>
+<% if @repository.default_environment_name == nil %>No default environment set, for details see <https://slashdeploy.io/docs>.<% end %>
 <% end %>

--- a/lib/slashdeploy/config.rb
+++ b/lib/slashdeploy/config.rb
@@ -34,6 +34,9 @@ module SlashDeploy
 
     attribute :environments, Hash[String => Environment]
 
+    # optional default_environment name.
+    attribute :default_environment, String, :default => nil
+
     # Public: Loads the raw yaml and initializes a new Config object from it.
     #
     # yaml - raw YAML formatted string

--- a/spec/features/commands_spec.rb
+++ b/spec/features/commands_spec.rb
@@ -433,10 +433,6 @@ RSpec.feature 'Slash Commands' do
   end
 
   scenario 'finding the environments I can deploy a repo to' do
-    command '/deploy where acme-inc/api', as: slack_accounts(:david)
-    #expect(command_response.message).to eq Slack::Message.new(text: "I don't know about any environments for acme-inc/api. For details about configuring environments, see <https://slashdeploy.io/docs>.")
-
-    #command '/deploy acme-inc/api to staging', as: slack_accounts(:david)
 
     command '/deploy where acme-inc/api', as: slack_accounts(:david)
     expect(command_response.message).to eq Slack::Message.new(text: <<-TEXT.strip_heredoc.strip)

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -30,38 +30,46 @@ RSpec.describe Repository, type: :model do
         expect(environment.name).to eq 'staging'
       end
     end
-
-    context 'when not given a name' do
-      it 'returns the default environment' do
-        repo = Repository.with_name('acme-inc/api')
-        repo.default_environment = 'production'
-        repo.raw_config = <<-YAML
-        environments:
-          production: {}
-          staging: {}
-        YAML
-        environment = repo.environment
-        expect(environment).to_not be_nil
-        expect(environment.name).to eq 'production'
-      end
-    end
   end
 
   describe '#default_environment' do
-    context 'when the repository has a default environment provided' do
-      it 'returns that value' do
-        repo = Repository.new(default_environment: 'staging')
-        expect(repo.default_environment).to eq 'staging'
+
+    before do
+      @repo = Repository.with_name('acme-inc/api')
+      @repo.configure! <<-YAML
+default_environment: production
+environments:
+  production:
+    aliases: [prod]
+  stage:
+    aliases: [staging]
+YAML
+
+      @env_prod = Environment.new(name: 'production', repository: @repo)
+      @env_stage = Environment.new(name: 'stage', repository: @repo)
+    end
+
+    context 'when not given a name' do
+      it 'returns the default environment' do
+        environment = @repo.environment
+        expect(environment).to_not be_nil
+        expect(environment.name).to eq "production"
       end
     end
 
-    context 'when the repository does not have a default environment' do
-      it 'returns nil' do
-        repo = Repository.new(default_environment: '')
-        expect(repo.default_environment).to be_nil
+    context 'when not given an alias' do
+      it 'repo returns the correct environment' do
+        environment = @repo.environment("prod")
+        expect(environment).to_not be_nil
+        expect(environment.name).to eq "production"
+      end
+    end
 
-        repo = Repository.new
-        expect(repo.default_environment).to be_nil
+    context 'when default_environment set' do
+      it 'repository and environment objects react correctly' do
+        expect(@env_prod.is_default?).to eq true
+        expect(@env_stage.is_default?).to eq false
+        expect(@repo.default_environment.name).to eq "production"
       end
     end
   end


### PR DESCRIPTION
Also alter environments message to show which environment is default

Also updates the `/docs` page with many of the new features we introduced.

	modified:   app/models/environment.rb
	modified:   app/models/repository.rb
	modified:   app/views/messages/environments.text.erb
	modified:   lib/slashdeploy/config.rb
	modified:   spec/features/commands_spec.rb
	modified:   spec/models/repository_spec.rb