### PR TITLE
Add latest command

### DIFF
--- a/app/commands/latest_command.rb
+++ b/app/commands/latest_command.rb
@@ -1,0 +1,15 @@
+# LatestCommand handles the `/deploy latest` subcommand.
+class LatestCommand < BaseCommand
+  def run
+    transaction do
+      repo = Repository.with_name(params['repository'])
+      return Slash.reply(ValidationErrorMessage.build(record: repo)) if repo.invalid?
+      
+      env = repo.environment(params['environment'])
+      last_deployment = slashdeploy.last_deployment(user, repo, env)
+
+      Slash.say LatestMessage.build \
+        last_deployment: last_deployment
+    end
+  end
+end

--- a/app/commands/slash_commands.rb
+++ b/app/commands/slash_commands.rb
@@ -19,6 +19,7 @@ class SlashCommands
     router.match match_regexp(/^check #{ENV} on #{REPO}$/), CheckCommand
     router.match match_regexp(/^boom$/), BoomCommand
     router.match match_regexp(/^#{REPO}(@#{REF})?( to #{ENV})?(?<force>!)?$/), DeployCommand
+    router.match match_regexp(/^latest #{REPO}( to #{ENV})?$/), LatestCommand
 
     router.not_found = -> (env) do
       env['params'] = { 'not_found' => true }

--- a/app/messages/help_message.rb
+++ b/app/messages/help_message.rb
@@ -9,6 +9,8 @@ To lock an environment: /deploy lock ENVIRONMENT on REPO: MESSAGE
 To unlock a previously locked environment: /deploy unlock ENVIRONMENT on REPO
 To unlock all locks you own: /deploy unlock all
 To check if an environment is locked: /deploy check ENVIRONMENT on REPO
+To get the latest deployment for a repo: /deploy latest REPO
+To get the latest deployment for a repo to a specific environment: /deploy latest REPO to ENVIRONMENT
 EOF
 
   values do

--- a/app/messages/latest_message.rb
+++ b/app/messages/latest_message.rb
@@ -14,7 +14,7 @@ class LatestMessage < SlackMessage
     Slack::Message.new text: text(last_deployment: last_deployment), attachments: [
       Slack::Attachment.new(
         color: '#3AA3E3',
-        title: "#{last_deployment.repository}/#{last_deployment.ref}",
+        title: "#{last_deployment.repository}@#{last_deployment.ref}",
         title_link: "https://github.com/#{last_deployment.repository}/commit/#{last_deployment.sha}",
         fields: fields
       )

--- a/app/messages/latest_message.rb
+++ b/app/messages/latest_message.rb
@@ -1,0 +1,23 @@
+class LatestMessage < SlackMessage
+  values do
+    attribute :last_deployment, Deployment
+  end
+
+  def to_message
+    fields = [
+      {
+        title: "Commit SHA",
+        value: last_deployment.sha
+      }
+    ]
+
+    Slack::Message.new text: text(last_deployment: last_deployment), attachments: [
+      Slack::Attachment.new(
+        color: '#3AA3E3',
+        title: "#{last_deployment.repository}/#{last_deployment.ref}",
+        title_link: "https://github.com/#{last_deployment.repository}/commit/#{last_deployment.sha}",
+        fields: fields
+      )
+    ]
+  end
+end

--- a/app/messages/latest_message.rb
+++ b/app/messages/latest_message.rb
@@ -16,7 +16,8 @@ class LatestMessage < SlackMessage
         color: '#3AA3E3',
         title: "#{last_deployment.repository}@#{last_deployment.ref}",
         title_link: "https://github.com/#{last_deployment.repository}/commit/#{last_deployment.sha}",
-        fields: fields
+        fields: fields,
+        footer: "<https://github.com/#{last_deployment.repository}/deployments|Check all the latest deployments here>"
       )
     ]
   end

--- a/app/views/messages/latest.text.erb
+++ b/app/views/messages/latest.text.erb
@@ -1,0 +1,1 @@
+Latest deployment for *<%= @last_deployment.repository %>* to environment *<%= @last_deployment.environment%>*

--- a/lib/slashdeploy/service.rb
+++ b/lib/slashdeploy/service.rb
@@ -116,6 +116,19 @@ module SlashDeploy
       end
     end
 
+    # Returns the last deployment for a repository and environment.
+    #
+    # user        - The User requesting the last deployment information.
+    # repo        - The repository to retrieve the last deployment from.
+    # environment - The Environment to retrieve the last deployment from.
+    #
+    # Returns github.last_deployment.
+    def last_deployment(user, repo, environment)
+      authorize! user, repo.to_s
+
+      last_deployment = github.last_deployment(user, repo.to_s, environment.to_s)
+    end
+
     # Attempts to lock the environment on the repo.
     #
     # environment - An Environment to lock.

--- a/spec/commands/slash_commands_spec.rb
+++ b/spec/commands/slash_commands_spec.rb
@@ -39,6 +39,9 @@ RSpec.describe SlashCommands do
       check_route(a, 'acme-inc/api@topic to staging!', DeployCommand, 'repository' => 'acme-inc/api', 'ref' => 'topic', 'environment' => 'staging', 'force' => '!')
 
       check_route(a, 'api to staging', DeployCommand, 'repository' => 'acme-inc/api', 'environment' => 'staging', 'force' => nil, 'ref' => nil)
+
+      check_route(a, 'latest acme-inc/api', LatestCommand, 'repository' => 'acme-inc/api', 'environment' => nil)
+      check_route(a, 'latest acme-inc/api to staging', LatestCommand, 'repository' => 'acme-inc/api', 'environment' => 'staging')
     end
 
     def check_route(account, text, expected_handler, expected_params)

--- a/spec/features/commands_spec.rb
+++ b/spec/features/commands_spec.rb
@@ -733,6 +733,10 @@ RSpec.feature 'Slash Commands' do
 
     command '/deploy latest acme-inc/api to production', as: slack_accounts(:david)
     expect(command_response.message).to eq expected_slack_msg
+
+    command '/deploy acme-inc/api@master to staging', as: slack_accounts(:david)
+    command '/deploy latest acme-inc/api', as: slack_accounts(:david)
+    expect(command_response.message).to eq expected_slack_msg
   end
   
   scenario 'checking the latest deployment for a repo without a default environment' do

--- a/spec/features/commands_spec.rb
+++ b/spec/features/commands_spec.rb
@@ -718,7 +718,7 @@ RSpec.feature 'Slash Commands' do
       attachments: [
         Slack::Attachment.new(
           color: '#3AA3E3',
-          title: 'acme-inc/api/master',
+          title: 'acme-inc/api@master',
           title_link: 'https://github.com/acme-inc/api/commit/ad80a1b3e1a94b98ce99b71a48f811f1',
           fields: expected_fields
         )
@@ -755,7 +755,7 @@ RSpec.feature 'Slash Commands' do
       attachments: [
         Slack::Attachment.new(
           color: '#3AA3E3',
-          title: 'acme-inc/api/topic',
+          title: 'acme-inc/api@topic',
           title_link: 'https://github.com/acme-inc/api/commit/4c7b474c6e1c81553a16d1082cebfa60',
           fields: expected_fields_staging
         )
@@ -774,7 +774,7 @@ RSpec.feature 'Slash Commands' do
       attachments: [
         Slack::Attachment.new(
           color: '#3AA3E3',
-          title: 'acme-inc/api/master',
+          title: 'acme-inc/api@master',
           title_link: 'https://github.com/acme-inc/api/commit/ad80a1b3e1a94b98ce99b71a48f811f1',
           fields: expected_fields_production
         )
@@ -819,7 +819,7 @@ RSpec.feature 'Slash Commands' do
       attachments: [
         Slack::Attachment.new(
           color: '#3AA3E3',
-          title: 'acme-inc/api/topic',
+          title: 'acme-inc/api@topic',
           title_link: 'https://github.com/acme-inc/api/commit/4c7b474c6e1c81553a16d1082cebfa60',
           fields: expected_fields_topic
         )
@@ -838,7 +838,7 @@ RSpec.feature 'Slash Commands' do
       attachments: [
         Slack::Attachment.new(
           color: '#3AA3E3',
-          title: 'acme-inc/api/master',
+          title: 'acme-inc/api@master',
           title_link: 'https://github.com/acme-inc/api/commit/ad80a1b3e1a94b98ce99b71a48f811f1',
           fields: expected_fields_master
         )

--- a/spec/features/commands_spec.rb
+++ b/spec/features/commands_spec.rb
@@ -720,14 +720,15 @@ RSpec.feature 'Slash Commands' do
           color: '#3AA3E3',
           title: 'acme-inc/api@master',
           title_link: 'https://github.com/acme-inc/api/commit/ad80a1b3e1a94b98ce99b71a48f811f1',
-          fields: expected_fields
+          fields: expected_fields,
+          footer: "<https://github.com/acme-inc/api/deployments|Check all the latest deployments here>"
         )
       ]
     
     )
 
     command '/deploy acme-inc/api@master to production', as: slack_accounts(:david)
-    
+
     command '/deploy latest acme-inc/api', as: slack_accounts(:david)
     expect(command_response.message).to eq expected_slack_msg
 
@@ -761,7 +762,8 @@ RSpec.feature 'Slash Commands' do
           color: '#3AA3E3',
           title: 'acme-inc/api@topic',
           title_link: 'https://github.com/acme-inc/api/commit/4c7b474c6e1c81553a16d1082cebfa60',
-          fields: expected_fields_staging
+          fields: expected_fields_staging,
+          footer: "<https://github.com/acme-inc/api/deployments|Check all the latest deployments here>"
         )
       ]
     )
@@ -780,7 +782,8 @@ RSpec.feature 'Slash Commands' do
           color: '#3AA3E3',
           title: 'acme-inc/api@master',
           title_link: 'https://github.com/acme-inc/api/commit/ad80a1b3e1a94b98ce99b71a48f811f1',
-          fields: expected_fields_production
+          fields: expected_fields_production,
+          footer: "<https://github.com/acme-inc/api/deployments|Check all the latest deployments here>"
         )
       ]
     )
@@ -825,7 +828,8 @@ RSpec.feature 'Slash Commands' do
           color: '#3AA3E3',
           title: 'acme-inc/api@topic',
           title_link: 'https://github.com/acme-inc/api/commit/4c7b474c6e1c81553a16d1082cebfa60',
-          fields: expected_fields_topic
+          fields: expected_fields_topic,
+          footer: "<https://github.com/acme-inc/api/deployments|Check all the latest deployments here>"
         )
       ]
     )
@@ -844,7 +848,8 @@ RSpec.feature 'Slash Commands' do
           color: '#3AA3E3',
           title: 'acme-inc/api@master',
           title_link: 'https://github.com/acme-inc/api/commit/ad80a1b3e1a94b98ce99b71a48f811f1',
-          fields: expected_fields_master
+          fields: expected_fields_master,
+          footer: "<https://github.com/acme-inc/api/deployments|Check all the latest deployments here>"
         )
       ]
     )


### PR DESCRIPTION
This PR fixes #25 adding `latest` command.
You can either pass it the environment you want to retrieve the latest deployment from or not:

`/deploy latest REPO`:
I wasn't sure about which would be the desired behaviour on this case, so proposing this:
  - If the repository have a default environment, it will return the latest deployment for that environment.
  - If the repository doesn't have a default environment, it will return the latest deployment for the whole repository, no matter which environment.

`/deploy latest REPO to ENVIRONMENT`:
Returns the latest deployment for a concrete environment.

Added a few specs also. One of them is commented because seems like the behaviour on the fake github client is not the same as on Octokit client, you can check the comments on the specs.
