### PR TITLE
Update faker deployments to simulate octokit behaviour

### DIFF
--- a/lib/github/client/fake.rb
+++ b/lib/github/client/fake.rb
@@ -34,16 +34,20 @@ module GitHub
           sha:         commits[req.repository][req.ref],
           environment: req.environment
         )
-        deployments[req.repository][req.environment] << deployment
+        deployments[req.repository] << deployment
         deployment
       end
 
       def get_deployment(_user, repository, _deployment_id)
-        deployments[repository]['production'].last
+        deployments[repository].select{|k| k[:environment].to_s.match("production")}.last
       end
 
       def last_deployment(_user, repository, environment)
-        deployments[repository][environment].last
+        if environment.nil? 
+          deployments[repository].last
+        else
+          deployments[repository].select{|k| k[:environment].to_s.match(environment)}.last
+        end
       end
 
       # the only test which uses this expects nil, to trigger watch dog.
@@ -63,9 +67,7 @@ module GitHub
           commits[repo] = {}
         end
         @deployments = Hash.new do |deployments, repo|
-          deployments[repo] = Hash.new do |repos, env|
-            repos[env] = []
-          end
+          deployments[repo] = []
         end
         @requests = []
       end

--- a/spec/features/commands_spec.rb
+++ b/spec/features/commands_spec.rb
@@ -791,13 +791,8 @@ RSpec.feature 'Slash Commands' do
     command '/deploy acme-inc/api@master to production', as: slack_accounts(:david)
     command '/deploy acme-inc/api@topic to staging', as: slack_accounts(:david)
     
-    # Latest deployment without environment set should return the latest 
-    # all over the repo (when there's no default environment).
-    # Octokit client returns the latest deployment on the whole repo if 
-    # no environment is set, however it is not working with the current github fake client
-    
-    #command '/deploy latest acme-inc/api', as: slack_accounts(:david)
-    #expect(command_response.message).to eq expected_slack_msg_staging
+    command '/deploy latest acme-inc/api', as: slack_accounts(:david)
+    expect(command_response.message).to eq expected_slack_msg_staging
 
     command '/deploy latest acme-inc/api to staging', as: slack_accounts(:david)
     expect(command_response.message).to eq expected_slack_msg_staging


### PR DESCRIPTION
This small PR is to fix the behaviour of the fake github client. Related with #143.

Passing an environment to retrieve the latest deployment of a repo was mandatory. Now when calling `last_deployment` with no environment it returns the latest over all the repo, as octokit does.