### PR TITLE
Add state field on latest command

### DIFF
--- a/app/commands/latest_command.rb
+++ b/app/commands/latest_command.rb
@@ -9,7 +9,8 @@ class LatestCommand < BaseCommand
       last_deployment = slashdeploy.last_deployment(user, repo, env)
 
       Slash.say LatestMessage.build \
-        last_deployment: last_deployment
+        last_deployment: last_deployment.last_deployment,
+        last_deployment_state: last_deployment.last_deployment_status.state
     end
   end
 end

--- a/app/messages/latest_message.rb
+++ b/app/messages/latest_message.rb
@@ -1,13 +1,20 @@
 class LatestMessage < SlackMessage
   values do
     attribute :last_deployment, Deployment
+    attribute :last_deployment_state, String
   end
 
   def to_message
     fields = [
       {
         title: "Commit SHA",
-        value: last_deployment.sha
+        value: last_deployment.sha[0..6],
+        short: true
+      },
+      {
+        title: "State",
+        value: "`#{last_deployment_state}`",
+        short: true
       }
     ]
 

--- a/app/models/last_deployment.rb
+++ b/app/models/last_deployment.rb
@@ -1,0 +1,10 @@
+# Represents the latest deployment for a repository and an environment
+class LastDeployment
+  include Virtus.value_object
+   values do
+    # The last deployment.
+    attribute :last_deployment, Deployment
+    # The last deployment status
+    attribute :last_deployment_status, DeploymentStatus
+  end
+end

--- a/lib/github/client/fake.rb
+++ b/lib/github/client/fake.rb
@@ -50,11 +50,15 @@ module GitHub
         end
       end
 
-      # the only test which uses this expects nil, to trigger watch dog.
+      # a test which uses this expects nil, to trigger watch dog.
       #   spec/features/commands_spec.rb:
       #     'github deployment does not start after 30 simulated secs and triggers watchdog'
-      def last_deployment_status(_user, _deployment_url)
-        nil
+      def last_deployment_status(_user, deployment_url)
+        return nil if deployment_url.include? "api_watchdog"
+
+        {
+          state: 'success'
+        }
       end
 
       def contents(_repository, _path)

--- a/lib/github/client/octokit.rb
+++ b/lib/github/client/octokit.rb
@@ -39,7 +39,7 @@ module GitHub
       def last_deployment_status(user, deployment_url)
         deployment_statuses = user.octokit_client.deployment_statuses(deployment_url)
         return if deployment_statuses.empty?
-        deployment_status_from_github(deployments_statuses.first)
+        deployment_status_from_github(deployment_statuses.first)
       end
 
       def access?(user, repository)
@@ -80,7 +80,8 @@ module GitHub
           description:    github_deployment_status.description,
           target_url:     github_deployment_status.target_url,
           deployment_url: github_deployment_status.deployment_url,
-          repository_url: github_deployment_status.repository_url
+          repository_url: github_deployment_status.repository_url,
+          state:          github_deployment_status.state
         )
       end
 

--- a/lib/slashdeploy/service.rb
+++ b/lib/slashdeploy/service.rb
@@ -122,11 +122,17 @@ module SlashDeploy
     # repo        - The repository to retrieve the last deployment from.
     # environment - The Environment to retrieve the last deployment from.
     #
-    # Returns github.last_deployment.
+    # Returns a LastDeployment.
     def last_deployment(user, repo, environment)
       authorize! user, repo.to_s
 
       last_deployment = github.last_deployment(user, repo.to_s, environment.to_s)
+      last_deployment_status = github.last_deployment_status(user, last_deployment.url)
+      
+      LastDeployment.new(
+        last_deployment: last_deployment,
+        last_deployment_status: last_deployment_status
+      )
     end
 
     # Attempts to lock the environment on the repo.


### PR DESCRIPTION
This PR add `state` field on the latest command. 

In order to show it on the slack message appropriately, I've truncated the commit SHA to 7 chars. If there are any visual aspects that you think may be improved don't hesitate to tell me.  👍 
