### PR TITLE
Add a rake task for requesting all users to re-authenticate with GitHub

### DIFF
--- a/app/messages/github_authenticate_message.rb
+++ b/app/messages/github_authenticate_message.rb
@@ -1,0 +1,9 @@
+class GitHubAuthenticateMessage < SlackMessage
+  values do
+    attribute :url, String
+  end
+
+  def to_message
+    Slack::Message.new text: "Please authenticate with GitHub: #{url}"
+  end
+end

--- a/db/migrate/20181211003305_add_timestampts_to_github_accounts.rb
+++ b/db/migrate/20181211003305_add_timestampts_to_github_accounts.rb
@@ -1,0 +1,5 @@
+class AddTimestamptsToGitHubAccounts < ActiveRecord::Migration
+  def change
+    add_timestamps :github_accounts, null: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -125,7 +125,9 @@ CREATE TABLE github_accounts (
     user_id integer,
     id integer NOT NULL,
     login character varying NOT NULL,
-    token character varying NOT NULL
+    token character varying NOT NULL,
+    created_at timestamp without time zone,
+    updated_at timestamp without time zone
 );
 
 
@@ -693,4 +695,6 @@ INSERT INTO schema_migrations (version) VALUES ('20161217031700');
 INSERT INTO schema_migrations (version) VALUES ('20170704235901');
 
 INSERT INTO schema_migrations (version) VALUES ('20180308001951');
+
+INSERT INTO schema_migrations (version) VALUES ('20181211003305');
 

--- a/lib/tasks/github.rake
+++ b/lib/tasks/github.rake
@@ -1,0 +1,18 @@
+namespace :github do
+  task :request_reauthenticate, [:user_id] => :environment do |t, args|
+    users = User.all
+    if user_id = args[:user_id]
+      users = [User.find(user_id)]
+    end
+
+    users.each do |user|
+      user.slack_accounts.each do |account|
+        puts "Requesting user #{user.id} to re-authenticate"
+        SlashDeploy.service.direct_message \
+          account, \
+          GitHubAuthenticateMessage, \
+          url: Rails.application.routes.url_helpers.oauth_url(provider: 'github')
+      end
+    end
+  end
+end


### PR DESCRIPTION
For legacy reasons, slashdeploy.io uses a client_id/client_secret from a GitHub OAuth app instead of the client_id/client_secret from the GitHub App.

GitHub apps now support all of the API calls that SlashDeploy uses, which means we can switch the client_id/client_secret over to the GitHub app.

This PR adds a rake task that will request all users to re-authenticate with GitHub so that we can eventually remove the legacy OAuth app.