### PR TITLE
Update octokit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem 'therubyracer'
 gem 'coffee-script'
 
 # Github API Client Library.
-gem 'octokit', '>= 4.9.0'
+gem 'octokit', '>= 4.16.0'
 
 # Used for interacting with Slack API.
 gem 'faraday', '0.9.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,7 +130,8 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    octokit (4.14.0)
+    octokit (4.16.0)
+      faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     oj (3.9.2)
     omniauth (1.9.0)
@@ -312,7 +313,7 @@ DEPENDENCIES
   jwt
   lograge
   oauth2
-  octokit (>= 4.9.0)
+  octokit (>= 4.16.0)
   oj
   omniauth
   omniauth-oauth2
@@ -342,4 +343,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.4
+   1.16.6

--- a/spec/github/app_spec.rb
+++ b/spec/github/app_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe GitHub::App do
        	  'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
        	  'Authorization'=>'Bearer eyJhbGciOiJSUzI1NiJ9.eyJpYXQiOjE0OTkyMjE1NjcsImV4cCI6MTQ5OTIyMTYyNywiaXNzIjoxMjM0fQ.pItH_NZcXZgwrQ2jTVHbGbCIScOmc1rp35NLzVkWqFJrRSaqdaUoxC_u0wrFJeaou2gswqPjXunVAnNmmr06VmaHK1j_0yKhXWy3xFKBIzXG4R9_cKUvTp2L0peE7DCg5Z-33p1sx7_Jw5tt4Lzn6rEns7sMpeN3QQY-KyKwgGlZppM1Adum5vVceu-Ui7Zzd2GAmmTKKbDxaEzm74K-8w1qpWYbSNfE9ZFLUWKxyGrJM1sOqK7m6l1CCgBRD4b_ufYjpVt2aVTNzylwz6fIYT6E9N_LA9IVCQlr4ygc8JFt2ZYFXbbRptPTIWQDDSEqMaGxQMQ_258gxwM7D9gtkQ',
        	  'Content-Type'=>'application/json',
-       	  'User-Agent'=>'Octokit Ruby Gem 4.14.0'
+       	  'User-Agent'=>'Octokit Ruby Gem 4.16.0'
            }).to_return(status: 200, body: { 'token': 'v1.1f699f1069f60xxx', 'expires_at': (now + 1.hour).iso8601 }.to_json, headers: { 'Content-Type' => 'application/json' })
 
       expect(time).to receive(:now).and_return(now)
@@ -48,7 +48,7 @@ RSpec.describe GitHub::App do
        	  'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
        	  'Authorization'=>'Bearer eyJhbGciOiJSUzI1NiJ9.eyJpYXQiOjE0OTkyMjUxNjcsImV4cCI6MTQ5OTIyNTIyNywiaXNzIjoxMjM0fQ.tR_fh9n3wys3TzjoteAj3ITGSFwYfBwuGfhVQUNDIWJPIs76H8sGRBTcHeUJPmcEfvGWhPf82uY8NrcjWyjyVmgdk-ahGSkrESHdY3nZJfX7WXJvOvIEM-8NuCyGFhJ2CYyPM0g0PThh_F8StbMI4TQ_mqVXuXk2TJowcxkzaYyG8vUMpiXENWqcEZExCPCnH6s5agxKDYyPuCBldT5ouiSeOhgwSc4xR5Iu3v6rrrz1nuhmUMnR9hVhJ5zn1c6Aw1BqF0nBHr3cLCaPOAd2xjm9poSnxY5JF82j45Xf6PVjreju2RPT7m9_HjZOOE_8vz1FgZlPSH2QP_qL24tgrA',
        	  'Content-Type'=>'application/json',
-       	  'User-Agent'=>'Octokit Ruby Gem 4.14.0'
+       	  'User-Agent'=>'Octokit Ruby Gem 4.16.0'
            }).to_return(status: 200, body: { 'token': 'v1.1f699f1069f60xxx', 'expires_at': (now + 1.hour).iso8601 }.to_json, headers: { 'Content-Type' => 'application/json' })
 
       expect(time).to receive(:now).and_return(now + 60.minutes).twice


### PR DESCRIPTION
We got an email saying that query params for API calls were deprecated (related https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/#deprecation-timeline). It was fixed for basic auth in https://github.com/octokit/octokit.rb/pull/1192, which was released as part of Octokit v4.16.0.

Not sure if this will fix the issue since the email we got referred to access token being passed as a query param and this deal with basic auth (client id and client secret), but I couldn't find anything else that used token auth that didn't go through Octokit.