### PR TITLE
Revert "WIP:If the user has an expired github OAuth token, re-authenticate them."

### DIFF
--- a/lib/slashdeploy/auth.rb
+++ b/lib/slashdeploy/auth.rb
@@ -31,17 +31,11 @@ module SlashDeploy
 
       begin
         handler.call(env)
-      rescue User::MissingGitHubAccount, Octokit::Unauthorized
-        # If User::MissingGitHubAccount the slack user doesn't have an
-        # associated GithubAccount.
-        #
-        # If Octokit::Unauthorized the slack user's associated GithubAccount's
-        # OAuth token which we persist in our database has expired.
-        #
-        # Either way, we ask them to authenticate with GitHub.
-        #
-        # We encode and sign the Slack user id within the state param so we
-        # know what slack user they are when the hit the GitHub callback.
+      rescue User::MissingGitHubAccount
+        # If we don't know this slack user, we'll ask them to authenticate
+        # with GitHub. We encode and sign the Slack user id within the state
+        # param so we know what slack user they are when the hit the GitHub
+        # callback.
         claims = {
           id: account.user.id,
           exp: EXPIRATION.from_now.to_i,


### PR DESCRIPTION
Reverts remind101/slashdeploy#118

This didn't fix the end user trouble I was seeing. What did was having the user go to:

- https://slashdeploy.io/auth/github

to reauthenticate with github.
