### PR TITLE
Make all uses of on or to fuzzy

### DIFF
--- a/app/commands/slash_commands.rb
+++ b/app/commands/slash_commands.rb
@@ -13,13 +13,13 @@ class SlashCommands
     router = Slash::Router.new
     router.match match_regexp(/^help$/), HelpCommand
     router.match match_regexp(/^where #{REPO}$/), EnvironmentsCommand
-    router.match match_regexp(/^lock #{ENV} on #{REPO}(:(?<message>.*(?<!\!$)))?(?<force>!)?$/), LockCommand
+    router.match match_regexp(/^lock #{ENV} (on|to){1} #{REPO}(:(?<message>.*(?<!\!$)))?(?<force>!)?$/), LockCommand
     router.match match_regexp(/^unlock all$/), UnlockAllCommand
-    router.match match_regexp(/^unlock #{ENV} on #{REPO}$/), UnlockCommand
-    router.match match_regexp(/^check #{ENV} on #{REPO}$/), CheckCommand
+    router.match match_regexp(/^unlock #{ENV} (on|to){1} #{REPO}$/), UnlockCommand
+    router.match match_regexp(/^check #{ENV} (on|to){1} #{REPO}$/), CheckCommand
     router.match match_regexp(/^boom$/), BoomCommand
-    router.match match_regexp(/^#{REPO}(@#{REF})?( to #{ENV})?(?<force>!)?$/), DeployCommand
-    router.match match_regexp(/^latest #{REPO}( to #{ENV})?$/), LatestCommand
+    router.match match_regexp(/^#{REPO}(@#{REF})?( (on|to){1} #{ENV})?(?<force>!)?$/), DeployCommand
+    router.match match_regexp(/^latest #{REPO}( (on|to){1} #{ENV})?$/), LatestCommand
 
     router.not_found = -> (env) do
       env['params'] = { 'not_found' => true }

--- a/app/commands/slash_commands.rb
+++ b/app/commands/slash_commands.rb
@@ -5,6 +5,7 @@ class SlashCommands
   REPO = /(?<repository>\S+?)/
   ENV  = /(?<environment>\S+?)/
   REF  = /(?<ref>\S+?)/
+  ON_TO = /(on|to){1}/
 
   attr_reader :router
 
@@ -13,13 +14,13 @@ class SlashCommands
     router = Slash::Router.new
     router.match match_regexp(/^help$/), HelpCommand
     router.match match_regexp(/^where #{REPO}$/), EnvironmentsCommand
-    router.match match_regexp(/^lock #{ENV} (on|to){1} #{REPO}(:(?<message>.*(?<!\!$)))?(?<force>!)?$/), LockCommand
+    router.match match_regexp(/^lock #{ENV} #{ON_TO} #{REPO}(:(?<message>.*(?<!\!$)))?(?<force>!)?$/), LockCommand
     router.match match_regexp(/^unlock all$/), UnlockAllCommand
-    router.match match_regexp(/^unlock #{ENV} (on|to){1} #{REPO}$/), UnlockCommand
-    router.match match_regexp(/^check #{ENV} (on|to){1} #{REPO}$/), CheckCommand
+    router.match match_regexp(/^unlock #{ENV} #{ON_TO} #{REPO}$/), UnlockCommand
+    router.match match_regexp(/^check #{ENV} #{ON_TO} #{REPO}$/), CheckCommand
     router.match match_regexp(/^boom$/), BoomCommand
-    router.match match_regexp(/^#{REPO}(@#{REF})?( (on|to){1} #{ENV})?(?<force>!)?$/), DeployCommand
-    router.match match_regexp(/^latest #{REPO}( (on|to){1} #{ENV})?$/), LatestCommand
+    router.match match_regexp(/^#{REPO}(@#{REF})?( #{ON_TO} #{ENV})?(?<force>!)?$/), DeployCommand
+    router.match match_regexp(/^latest #{REPO}( #{ON_TO} #{ENV})?$/), LatestCommand
 
     router.not_found = -> (env) do
       env['params'] = { 'not_found' => true }

--- a/app/messages/help_message.rb
+++ b/app/messages/help_message.rb
@@ -1,8 +1,8 @@
 class HelpMessage < SlackMessage
   USAGE = <<EOF
 To deploy a repo to the default environment: /deploy REPO
-To deploy a repo to a specific environment: /deploy REPO to ENVIRONMENT
-To deploy a repo to a specific branch: /deploy REPO@REF to ENVIRONMENT
+To deploy a repo to a specific environment: /deploy REPO on ENVIRONMENT
+To deploy a repo to a specific branch: /deploy REPO@REF on ENVIRONMENT
 To force a deployment, ignoring any commit statuses: /deploy REPO!
 To list known environments you can deploy a repo to: /deploy where REPO
 To lock an environment: /deploy lock ENVIRONMENT on REPO: MESSAGE
@@ -10,7 +10,7 @@ To unlock a previously locked environment: /deploy unlock ENVIRONMENT on REPO
 To unlock all locks you own: /deploy unlock all
 To check if an environment is locked: /deploy check ENVIRONMENT on REPO
 To get the latest deployment for a repo: /deploy latest REPO
-To get the latest deployment for a repo to a specific environment: /deploy latest REPO to ENVIRONMENT
+To get the latest deployment for a repo to a specific environment: /deploy latest REPO on ENVIRONMENT
 EOF
 
   values do

--- a/app/views/documentation/index.html.erb
+++ b/app/views/documentation/index.html.erb
@@ -33,7 +33,7 @@
     <p>To deploy the default ref (master) to the default environment (production).</p>
     <p><code>/deploy acme-inc/api</code></p>
     <p>To deploy the default ref (master) to a different environment.</p>
-    <p><code>/deploy acme-inc/api to staging</code></p>
+    <p><code>/deploy acme-inc/api on staging</code></p>
     <p>To deploy a branch (or git sha, or git tag) to the default environment.</p>
     <p><code>/deploy acme-inc/api@branch</code></p>
     <p>By default, all GitHub commit statuses will be checked before creating a deployment, you can disable this check by using the <code>!</code> flag.</p>
@@ -47,7 +47,7 @@
     <p>SlashDeploy also allows you to "lock" environments. If for example, I wanted to test a migration on the staging environment, I can lock it with a message.</p>
     <p><code>/deploy lock staging on acme-inc/api: I'm testing a migration</code></p>
     <p>If any of my other team members try to deploy to the staging environment, they'll see the lock message.</p>
-    <p><code>/deploy acme-inc/api to staging</code></p>
+    <p><code>/deploy acme-inc/api on staging</code></p>
     <p>When I'm done testing my changes, I can unlock the environment so others can deploy to it again.</p>
     <p><code>/deploy unlock staging on acme-inc/api</code></p>
     <p>When I'm done for the day, I can release all my locks.
@@ -59,7 +59,7 @@
 
     <p>You may configure SlashDeploy for your project by putting a <a href="#.slashdeploy.yml">.slashdeploy.yml</a> file in the root of your git repository.
     <p>Here is a heavily commented <a href="#.slashdeploy.yml">.slashdeploy.yml</a> example:
-      <pre>---
+    <pre>---
 # teach SlashDeploy which environment is default. optional.
 # used when environment is not passed to a `/deploy` command.
 default_environment: production
@@ -87,7 +87,7 @@ environments:
     <p>If you utilize Github "Branch Protection Rules", you should likely use the same set of "Require status checks" under <code>required_contexts</code>.</p>
     <p>This example <a href="#.slashdeploy.yml">.slashdeploy.yml</a> file will automatically deploy the <code>master</code> branch to the <code>production</code> environment, once tests are passing on CircleCI:</p>
     <p>
-      <pre>---
+    <pre>---
 environments:
   production:
 
@@ -96,7 +96,7 @@ environments:
 
       # Specify any git "ref" (tag, branch, etc) to auto deploy when pushed to.
       ref: refs/heads/master
-  
+
       # To deploy only after a set of GitHub commit statuses pass,
       # configure required_contexts (optional).
       required_contexts:
@@ -120,15 +120,15 @@ environments:
     <h5 id="troubleshooting">Troubleshooting</h5>
     <p>Here we have some debugging information about the common issues and how to resolve them.
     <dl>
-        <dt id="error-1">Error 1: <small>The deployment did not start</small></dt>
+      <dt id="error-1">Error 1: <small>The deployment did not start</small></dt>
       <dd>If a deployment does not start in
-      <%= time_ago_in_words(GithubDeploymentWatchdogWorker::DEFAULT_DELAY.from_now, include_seconds: true) %>, 
-      you will get a Slack notification letting you know something went wrong. This might happen for a number of reasons, so check the following.
-      <ul>
-        <li>make sure the repo's <a href="#.slashdeploy.yml">.slashdeploy.yml</a> file is configured properly</li>
-        <li>make sure the repo has a Github Deployment Integration (and Webhooks) to handle deployment events</li>
-        <li>make sure the service handling the deployment events is working and sending Deployment Status updates to Github</li>
-        <li>make sure the service handling the deployment events is not filtering or ignoring deployment requests. For example, it will deploy to <code>production</code>, however the  provided environment in the deployment event was <code>prod</code>.
+        <%= time_ago_in_words(GithubDeploymentWatchdogWorker::DEFAULT_DELAY.from_now, include_seconds: true) %>,
+        you will get a Slack notification letting you know something went wrong. This might happen for a number of reasons, so check the following.
+        <ul>
+          <li>make sure the repo's <a href="#.slashdeploy.yml">.slashdeploy.yml</a> file is configured properly</li>
+          <li>make sure the repo has a Github Deployment Integration (and Webhooks) to handle deployment events</li>
+          <li>make sure the service handling the deployment events is working and sending Deployment Status updates to Github</li>
+          <li>make sure the service handling the deployment events is not filtering or ignoring deployment requests. For example, it will deploy to <code>production</code>, however the provided environment in the deployment event was <code>prod</code>.
       </dd>
       <dt id="error-2">Error 2: <small>A required commit status context is stuck in pending</small></dt>
       <dd>Inside the repo's <a href="#.slashdeploy.yml">.slashdeploy.yml</a> a list of <code>required_contexts</code> was defined which need to move into the <code>success</code> state in order to continue. For some reason, after <%= time_ago_in_words(AutoDeploymentWatchdogWorker::DEFAULT_DELAY.from_now) %> of waiting, at least one of these <code>required_contexts</code> are stuck in the <code>pending</code> state instead of transitioning to <code>success</code>, <code>failure</code>, or <code>error</code>. If you fix this issue your deployment will likely continue.</dd>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,3 +24,5 @@ services:
     command: bash
   postgres:
     image: postgres:9.6
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust

--- a/spec/commands/slash_commands_spec.rb
+++ b/spec/commands/slash_commands_spec.rb
@@ -12,18 +12,22 @@ RSpec.describe SlashCommands do
 
       check_route(a, 'where acme-inc/api', EnvironmentsCommand, 'repository' => 'acme-inc/api')
       check_route(a, 'where api', EnvironmentsCommand, 'repository' => 'acme-inc/api')
-
-      check_route(a, 'lock staging on acme-inc/api: Doing stuff', LockCommand, 'repository' => 'acme-inc/api', 'environment' => 'staging', 'message' => ' Doing stuff', 'force' => nil)
-      check_route(a, 'lock staging on acme-inc/api', LockCommand, 'repository' => 'acme-inc/api', 'environment' => 'staging', 'message' => nil, 'force' => nil)
-      check_route(a, 'lock staging on api', LockCommand, 'repository' => 'acme-inc/api', 'environment' => 'staging', 'message' => nil, 'force' => nil)
-      check_route(a, 'lock staging on api!', LockCommand, 'repository' => 'acme-inc/api', 'environment' => 'staging', 'message' => nil, 'force' => '!')
-      check_route(a, 'lock staging on api: Doing stuff!', LockCommand, 'repository' => 'acme-inc/api', 'environment' => 'staging', 'message' => ' Doing stuff', 'force' => '!')
-
+      %w(on to).each { |x|
+        check_route(a, 'lock staging %s acme-inc/api: Doing stuff' % x, LockCommand, 'repository' => 'acme-inc/api', 'environment' => 'staging', 'message' => ' Doing stuff', 'force' => nil)
+        check_route(a, 'lock staging %s acme-inc/api' % x, LockCommand, 'repository' => 'acme-inc/api', 'environment' => 'staging', 'message' => nil, 'force' => nil)
+        check_route(a, 'lock staging %s api' % x, LockCommand, 'repository' => 'acme-inc/api', 'environment' => 'staging', 'message' => nil, 'force' => nil)
+        check_route(a, 'lock staging %s api!' % x, LockCommand, 'repository' => 'acme-inc/api', 'environment' => 'staging', 'message' => nil, 'force' => '!')
+        check_route(a, 'lock staging %s api: Doing stuff!' % x, LockCommand, 'repository' => 'acme-inc/api', 'environment' => 'staging', 'message' => ' Doing stuff', 'force' => '!')
+      }
       check_route(a, 'unlock all', UnlockAllCommand, {})
-      check_route(a, 'unlock staging on acme-inc/api', UnlockCommand, 'repository' => 'acme-inc/api', 'environment' => 'staging')
-      check_route(a, 'unlock staging on api', UnlockCommand, 'repository' => 'acme-inc/api', 'environment' => 'staging')
+      %w(on to).each { |x|
+        check_route(a, 'unlock staging %s acme-inc/api' % x, UnlockCommand, 'repository' => 'acme-inc/api', 'environment' => 'staging')
+        check_route(a, 'unlock staging %s api' % x, UnlockCommand, 'repository' => 'acme-inc/api', 'environment' => 'staging')
+      }
 
-      check_route(a, 'check production on acme-inc/api', CheckCommand, 'repository' => 'acme-inc/api', 'environment' => 'production')
+      %w(on to).each { |x|
+        check_route(a, 'check production %s acme-inc/api' % x, CheckCommand, 'repository' => 'acme-inc/api', 'environment' => 'production')
+      }
 
       check_route(a, 'boom', BoomCommand, {})
 
@@ -31,17 +35,19 @@ RSpec.describe SlashCommands do
       check_route(a, 'acme-inc/api!', DeployCommand, 'repository' => 'acme-inc/api', 'force' => '!', 'ref' => nil, 'environment' => nil)
       check_route(a, 'acme-inc/api@topic', DeployCommand, 'repository' => 'acme-inc/api', 'ref' => 'topic', 'force' => nil, 'environment' => nil)
       check_route(a, 'acme-inc/api@topic!', DeployCommand, 'repository' => 'acme-inc/api', 'ref' => 'topic', 'force' => '!', 'environment' => nil)
-      check_route(a, 'acme-inc/api to staging', DeployCommand, 'repository' => 'acme-inc/api', 'environment' => 'staging', 'force' => nil, 'ref' => nil)
-      check_route(a, 'acme-inc/api to staging!', DeployCommand, 'repository' => 'acme-inc/api', 'environment' => 'staging', 'force' => '!', 'ref' => nil)
-      check_route(a, 'acme-inc/api to staging', DeployCommand, 'repository' => 'acme-inc/api', 'environment' => 'staging', 'force' => nil, 'ref' => nil)
-      check_route(a, 'acme-inc/api to staging!', DeployCommand, 'repository' => 'acme-inc/api', 'environment' => 'staging', 'force' => '!', 'ref' => nil)
-      check_route(a, 'acme-inc/api@topic to staging', DeployCommand, 'repository' => 'acme-inc/api', 'ref' => 'topic', 'environment' => 'staging', 'force' => nil)
-      check_route(a, 'acme-inc/api@topic to staging!', DeployCommand, 'repository' => 'acme-inc/api', 'ref' => 'topic', 'environment' => 'staging', 'force' => '!')
+      %w(on to).each { |x|
+        check_route(a, 'acme-inc/api %s staging' % x, DeployCommand, 'repository' => 'acme-inc/api', 'environment' => 'staging', 'force' => nil, 'ref' => nil)
+        check_route(a, 'acme-inc/api %s staging!' % x, DeployCommand, 'repository' => 'acme-inc/api', 'environment' => 'staging', 'force' => '!', 'ref' => nil)
+        check_route(a, 'acme-inc/api %s staging' % x, DeployCommand, 'repository' => 'acme-inc/api', 'environment' => 'staging', 'force' => nil, 'ref' => nil)
+        check_route(a, 'acme-inc/api %s staging!' % x, DeployCommand, 'repository' => 'acme-inc/api', 'environment' => 'staging', 'force' => '!', 'ref' => nil)
+        check_route(a, 'acme-inc/api@topic %s staging' % x, DeployCommand, 'repository' => 'acme-inc/api', 'ref' => 'topic', 'environment' => 'staging', 'force' => nil)
+        check_route(a, 'acme-inc/api@topic %s staging!' % x, DeployCommand, 'repository' => 'acme-inc/api', 'ref' => 'topic', 'environment' => 'staging', 'force' => '!')
 
-      check_route(a, 'api to staging', DeployCommand, 'repository' => 'acme-inc/api', 'environment' => 'staging', 'force' => nil, 'ref' => nil)
+        check_route(a, 'api %s staging' % x, DeployCommand, 'repository' => 'acme-inc/api', 'environment' => 'staging', 'force' => nil, 'ref' => nil)
 
+        check_route(a, 'latest acme-inc/api %s staging' % x, LatestCommand, 'repository' => 'acme-inc/api', 'environment' => 'staging')
+      }
       check_route(a, 'latest acme-inc/api', LatestCommand, 'repository' => 'acme-inc/api', 'environment' => nil)
-      check_route(a, 'latest acme-inc/api to staging', LatestCommand, 'repository' => 'acme-inc/api', 'environment' => 'staging')
     end
 
     def check_route(account, text, expected_handler, expected_params)


### PR DESCRIPTION
/deploy uses on or to for similar meanings and can be a frustration point when moving between different /deploy commands. This allows the use of "to" or "on" in those places to reduce that frustration.

Aldo updated docker-compose to allow connection in the test and shell