### PR TITLE
Fix Slack OAuth flow bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 /spec/examples.txt
 .env*
 *.pem
+.byebug_history
 
 # Ignore asdf ruby version manager
 .tool-versions

--- a/Gemfile
+++ b/Gemfile
@@ -69,4 +69,5 @@ group :development do
   gem 'foreman'
   gem 'brakeman'
   gem 'dotenv-rails', '~> 2.2'
+  gem 'byebug'
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -23,7 +23,9 @@ class SessionsController < ApplicationController
   end
 
   def create
-    SlackBot.from_auth_hash(auth_hash) if auth_hash[:provider] == 'slack' && auth_hash[:extra][:bot_info].present?
+    if auth_hash[:provider] == 'slack' && auth_hash[:extra][:bot_info].present?
+      SlackBot.from_auth_hash(auth_hash)
+    end
 
     User.transaction do
       account = ConnectedAccount.from_auth_hash(auth_hash)

--- a/app/models/github_account.rb
+++ b/app/models/github_account.rb
@@ -3,9 +3,11 @@ class GitHubAccount < ActiveRecord::Base
   belongs_to :user
 
   def self.attributes_from_auth_hash(auth_hash)
-    { id: auth_hash[:uid],
+    {
+      id: auth_hash[:uid],
       login: auth_hash[:info][:nickname],
-      token: auth_hash[:credentials][:token] }
+      token: auth_hash[:credentials][:token],
+    }
   end
 
   def self.create_from_auth_hash(auth_hash)

--- a/app/models/slack_account.rb
+++ b/app/models/slack_account.rb
@@ -18,7 +18,6 @@ class SlackAccount < ActiveRecord::Base
 
     # TODO: This should just be an upsert
     team = SlackTeam.find_or_initialize_by(id: auth_hash[:info][:team_id]) do |t|
-      # team_domain doesn't appear to be set, so we fall back to team_id
       t.domain = domain
     end
 

--- a/app/models/slack_account.rb
+++ b/app/models/slack_account.rb
@@ -13,8 +13,13 @@ class SlackAccount < ActiveRecord::Base
   end
 
   def self.create_from_auth_hash(auth_hash)
+    # Extract the domain from the url
+    domain = URI.parse(auth_hash[:extra][:raw_info][:url]).host.gsub(/\.slack.com/, "")
+
+    # TODO: This should just be an upsert
     team = SlackTeam.find_or_initialize_by(id: auth_hash[:info][:team_id]) do |t|
-      t.domain = auth_hash[:info][:team_domain]
+      # team_domain doesn't appear to be set, so we fall back to team_id
+      t.domain = domain
     end
 
     create! attributes_from_auth_hash(auth_hash).merge(slack_team: team)

--- a/app/models/slack_bot.rb
+++ b/app/models/slack_bot.rb
@@ -3,7 +3,7 @@ class SlackBot < ActiveRecord::Base
 
   def self.from_auth_hash(auth_hash)
     bot_info = auth_hash[:extra][:bot_info]
-    bot = find_by(id: bot_info[:bot_user_id])
+    bot = find_by(id: bot_info[:bot_access_token])
     if bot
       bot.update_attributes(:access_token => bot_info[:bot_access_token])
     else

--- a/app/models/slack_bot.rb
+++ b/app/models/slack_bot.rb
@@ -2,14 +2,14 @@ class SlackBot < ActiveRecord::Base
   belongs_to :slack_team
 
   def self.from_auth_hash(auth_hash)
-    bot_info = auth_hash[:extra][:bot_info]
+    bot_info = auth_hash.fetch(:extra).fetch(:bot_info)
     bot = find_by(id: bot_info.fetch(:bot_access_token))
     if bot
       bot.update_attributes(access_token: bot_info.fetch(:bot_access_token))
     else
-      create(id: bot_info[:bot_access_token]) do |bot|
-        bot.access_token = bot_info[:bot_access_token]
-        bot.slack_team_id = auth_hash[:info][:team_id]
+      create(id: bot_info.fetch(:bot_access_token)) do |bot|
+        bot.access_token = bot_info.fetch(:bot_access_token)
+        bot.slack_team_id = auth_hash.fetch(:info).fetch(:team_id)
       end
     end
   end

--- a/app/models/slack_bot.rb
+++ b/app/models/slack_bot.rb
@@ -3,9 +3,9 @@ class SlackBot < ActiveRecord::Base
 
   def self.from_auth_hash(auth_hash)
     bot_info = auth_hash[:extra][:bot_info]
-    bot = find_by(id: bot_info[:bot_access_token])
+    bot = find_by(id: bot_info.fetch(:bot_access_token))
     if bot
-      bot.update_attributes(:access_token => bot_info[:bot_access_token])
+      bot.update_attributes(access_token: bot_info.fetch(:bot_access_token))
     else
       create(id: bot_info[:bot_access_token]) do |bot|
         bot.access_token = bot_info[:bot_access_token]

--- a/spec/features/add_to_slack_spec.rb
+++ b/spec/features/add_to_slack_spec.rb
@@ -20,6 +20,9 @@ RSpec.feature 'Add to Slack' do
         token: 'xoxt-23984754863-2348975623103'
       },
       extra: {
+        raw_info: {
+          url: "https://some-org_name.slack.com"
+        },
         bot_info: {
           bot_user_id: 'UTTTTTTTTTTR',
           bot_access_token: 'xoxb-XXXXXXXXXXXX-TTTTTTTTTTTTTT'
@@ -31,5 +34,37 @@ RSpec.feature 'Add to Slack' do
       visit '/auth/slack/callback'
     end.to change { SlackBot.count }.by(1)
     # expect(page).to have_content 'Success!'
+  end
+
+  scenario 'clicking the Add to Slack button a second time' do
+    OmniAuth.config.mock_auth[:slack] = OmniAuth::AuthHash.new(
+      provider: 'slack',
+      uid: '123545',
+      info: {
+        nickname: 'joe',
+        team_id: 'XXXXXXXXXX',
+        team_domain: 'acme'
+      },
+      credentials: {
+        token: 'xoxt-23984754863-2348975623103'
+      },
+      extra: {
+        raw_info: {
+          url: "https://some-org_name.slack.com"
+        },
+        bot_info: {
+          bot_user_id: 'UTTTTTTTTTTR',
+          bot_access_token: 'xoxb-XXXXXXXXXXXX-TTTTTTTTTTTTTT'
+        }
+      }
+    )
+
+    expect do
+      visit '/auth/slack/callback'
+    end.to change { SlackBot.count }.by(1)
+
+    expect do
+      visit '/auth/slack/callback'
+    end.to change { SlackBot.count }.by(0)
   end
 end


### PR DESCRIPTION
This fixes 2 (what I believe to be) bugs in the current code:

1. `app/models/slack_account.rb` was attempting to use
  `auth_hash[:info][:team_domain]` to set the team domain (actually the
  subdomain prepended to `slack.com` to form the URL to a workspace. That
  key does not exist in the OAuth data; I suspect it used to and that we
  haven't updated the code since Slack made API changes.
  Unfortunately, per
  https://api.slack.com/authentication/oauth-v2#waiting, Slack no longer
  returns the team domain. They do however return the URL to the
  workspace. I updated the code to extract the subdomain from the
  workspace URL and use that as the domain.

2. `app/models/slack_bot.rb` was attempting to use
  `bot_info[:bot_user_id]` to get the bot user id, which also does not
  exist as far as I can tell. I updated it to use
  `bot_info[:bot_access_token]`, which is what the code uses immediately
  below; I think this was an actual bug where the two should be
  referencing the same keys.

It also tidies up code in a few places to improve readability.