### PR TITLE
Switch Github auth to use header instead of query param

### DIFF
--- a/lib/omniauth/strategies/github.rb
+++ b/lib/omniauth/strategies/github.rb
@@ -41,7 +41,7 @@ module OmniAuth
       end
 
       def raw_info
-        access_token.options[:mode] = :query
+        access_token.options[:mode] = :header
         @raw_info ||= access_token.get('user').parsed
       end
 
@@ -57,7 +57,7 @@ module OmniAuth
       # The new /user/emails API - http://developer.github.com/v3/users/emails/#future-response
       def emails
         return [] unless email_access_allowed?
-        access_token.options[:mode] = :query
+        access_token.options[:mode] = :header
         @emails ||= access_token.get('user/emails', headers: { 'Accept' => 'application/vnd.github.v3' }).parsed
       end
 


### PR DESCRIPTION
Per https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/ the query method of auth is going away. 

See discussion here: https://remind.slack.com/archives/C03GHL501/p1623094058309700