### PR TITLE
Revert "Update default_ref method"

### DIFF
--- a/app/models/environment.rb
+++ b/app/models/environment.rb
@@ -79,11 +79,7 @@ class Environment < ActiveRecord::Base
 
   # The default git ref to deploy when none is provided for this environment.
   def default_ref
-    client_default_branch || super.presence || self.class.default_ref
-  end
-
-  def client_default_branch
-    @client_default_branch ||= Octokit.client.repository(repository.name).default_branch
+    super.presence || self.class.default_ref
   end
 
   def self.default_ref

--- a/spec/features/commands_spec.rb
+++ b/spec/features/commands_spec.rb
@@ -11,16 +11,6 @@ RSpec.feature 'Slash Commands' do
     HEAD('acme-inc/api', 'master',  'ad80a1b3e1a94b98ce99b71a48f811f1')
     HEAD('acme-inc/api', 'topic',   '4c7b474c6e1c81553a16d1082cebfa60')
     HEAD('acme-inc/api', 'failing', '46c2acc4e588924340adcd108cfc948b')
-
-    stub_request(:get, "https://api.github.com/repos/acme-inc/api").
-      with(
-        headers: {
-        'Accept'=>'application/vnd.github.v3+json',
-        'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-        'Content-Type'=>'application/json',
-        'User-Agent'=>'Octokit Ruby Gem 4.16.0'
-        }).
-      to_return(status: 200, body: {'default_branch': 'master'}.to_json, headers: { 'Content-Type' => 'application/json' })
   end
 
   after do
@@ -686,15 +676,7 @@ RSpec.feature 'Slash Commands' do
       production: {}
       staging: {}
     YAML
-    stub_request(:get, "https://api.github.com/repos/acme-inc/api_watchdog").
-      with(
-        headers: {
-          'Accept'=>'application/vnd.github.v3+json',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Content-Type'=>'application/json',
-          'User-Agent'=>'Octokit Ruby Gem 4.16.0'
-        }).
-      to_return(status: 200, body: {'default_branch': 'master'}.to_json, headers: { 'Content-Type' => 'application/json' })
+    
     # make sure our queue is clear before starting test.
     GithubDeploymentWatchdogWorker.clear
 

--- a/spec/models/environment_spec.rb
+++ b/spec/models/environment_spec.rb
@@ -1,17 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Environment, type: :model do
-  before do
-    stub_request(:get, "https://api.github.com/repos/acme-inc/api").
-        with(
-          headers: {
-          'Accept'=>'application/vnd.github.v3+json',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Content-Type'=>'application/json',
-          'User-Agent'=>'Octokit Ruby Gem 4.16.0'
-          }).
-        to_return(status: 200, body: {'default_branch': 'main'}.to_json, headers: { 'Content-Type' => 'application/json' })
-  end
   describe '#in_channel' do
     it 'defaults to true for production environments' do
       environment = Environment.new(name: 'production')
@@ -26,30 +15,19 @@ RSpec.describe Environment, type: :model do
 
   describe '#default_ref' do
     context 'when the environment has a default ref provided' do
-      it 'returns that value if no default_branch is provided' do
-         stub_request(:get, "https://api.github.com/repos/acme-inc/api").
-        with(
-          headers: {
-          'Accept'=>'application/vnd.github.v3+json',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Content-Type'=>'application/json',
-          'User-Agent'=>'Octokit Ruby Gem 4.16.0'
-          }).
-        to_return(status: 200, body: {}.to_json, headers: { 'Content-Type' => 'application/json' })
-        repo = Repository.with_name('acme-inc/api')
-        environment = Environment.new(default_ref: 'develop', repository: repo)
+      it 'returns that value' do
+        environment = Environment.new(default_ref: 'develop')
         expect(environment.default_ref).to eq 'develop'
       end
     end
 
     context 'when the environment does not have a default ref' do
       it 'returns the global default' do
-        repo = Repository.with_name('acme-inc/api')
-        environment = Environment.new(default_ref: '', repository: repo)
-        expect(environment.default_ref).to eq 'main'
+        environment = Environment.new(default_ref: '')
+        expect(environment.default_ref).to eq 'master'
 
-        environment = Environment.new(repository: repo)
-        expect(environment.default_ref).to eq 'main'
+        environment = Environment.new
+        expect(environment.default_ref).to eq 'master'
       end
     end
   end
@@ -59,10 +37,10 @@ RSpec.describe Environment, type: :model do
       it 'returns the correct value' do
         repo = Repository.with_name('acme-inc/api')
         repo.configure! <<-YAML
-                        environments:
-                          production:
-                            aliases: [prod]
-                        YAML
+environments:
+  production:
+    aliases: [prod]
+YAML
 
         environment = Environment.new(name: 'production', repository: repo)
         expect(environment.match_name?('production')).to eq true

--- a/spec/slashdeploy/config_spec.rb
+++ b/spec/slashdeploy/config_spec.rb
@@ -12,12 +12,12 @@ environments:
     aliases:
     - prod
     continuous_delivery:
-      ref: ref/heads/main
+      ref: ref/heads/master
 YAML
 
       expect(config.environments.length).to eq 2
       expect(config.environments["staging"].aliases).to eq ["stage"]
-      expect(config.environments["production"].continuous_delivery.ref).to eq "ref/heads/main"
+      expect(config.environments["production"].continuous_delivery.ref).to eq "ref/heads/master"
     end
   end
 end


### PR DESCRIPTION
This reverts commit 4cbfa9724f716dc685e9c66396e95aaf5b1dc380.

This was causing some issues when making GitHub API calls to get the
default branch for private repositories, since the call was unauthed.
Reverting this until we find a way to authenticate these calls.